### PR TITLE
Implement schema-driven setup, pool, and sharing tools

### DIFF
--- a/data/trip.json
+++ b/data/trip.json
@@ -1,0 +1,411 @@
+{
+  "version": 2,
+  "storage": {
+    "baseKey": "jp-canvas6",
+    "schema": 2
+  },
+  "trip": {
+    "title": "Japan Trip — Nov 14–30, 2025",
+    "range": { "start": "2025-11-14", "end": "2025-11-30" },
+    "baseLocation": "osaka"
+  },
+  "people": [
+    { "id": "Nana", "label": "Nana", "color": "#F7E6EC", "constraints": { "workDays": ["Tuesday", "Friday"], "maxAway": 3 } },
+    { "id": "Nicole", "label": "Nicole", "color": "#FFE4F0" },
+    { "id": "Ken", "label": "Ken", "color": "#EAF7EA" },
+    { "id": "James", "label": "James", "color": "#E6EFFA" },
+    { "id": "Phil", "label": "Phil", "color": "#E5F4F1" }
+  ],
+  "locations": [
+    { "id": "osaka", "label": "Osaka/Hirakata", "color": "#2D3A64" },
+    { "id": "kyoto", "label": "Kyoto/Nara/Kōyasan", "color": "#C84E4E" },
+    { "id": "kobe", "label": "Kobe/Arima/Himeji", "color": "#7FAFAE" },
+    { "id": "tokyo", "label": "Tokyo/Chiba", "color": "#EECAD0" },
+    { "id": "work", "label": "Work/Travel", "color": "#9A948C" }
+  ],
+  "themes": {
+    "osaka": "Osaka base day",
+    "kyoto": "Old streets & leaves",
+    "kobe": "Onsen & castles",
+    "tokyo": "Friends & arcades",
+    "work": "Travel / admin"
+  },
+  "coordinates": {
+    "dotonbori": [34.6687, 135.5013],
+    "umedaSky": [34.7051, 135.4899],
+    "abenoHarukas": [34.6464, 135.5134],
+    "midosujiIllumination": [34.6865, 135.4983],
+    "osakaGermanMarket": [34.7023, 135.4979],
+    "nakazakicho": [34.7084, 135.5099],
+    "kuromonMarket": [34.6659, 135.5079],
+    "kaiyukan": [34.6545, 135.4295],
+    "nagaiBotanical": [34.6118, 135.5169],
+    "arashiyama": [35.0136, 135.6736],
+    "kiyomizudera": [34.9948, 135.785],
+    "fushimiInari": [34.9671, 135.7727],
+    "uji": [34.8846, 135.8033],
+    "naraPark": [34.6851, 135.843],
+    "okunoin": [34.215, 135.5858],
+    "eikando": [35.0156, 135.7967],
+    "rurikoin": [35.0866, 135.7869],
+    "philosophersPath": [35.0284, 135.7949],
+    "kurama": [35.1098, 135.7682],
+    "kibune": [35.1164, 135.7629],
+    "toeiKyoto": [34.9989, 135.7062],
+    "arimaOnsen": [34.7968, 135.2495],
+    "harborland": [34.6785, 135.1787],
+    "kitanoIjinkan": [34.6994, 135.1917],
+    "himejiCastle": [34.8393, 134.6939],
+    "disneyResort": [35.6339, 139.8864],
+    "teamlabPlanets": [35.6496, 139.7916],
+    "teamlabBorderless": [35.657, 139.7546],
+    "ghibliMuseum": [35.6962, 139.5704],
+    "odaiba": [35.6267, 139.7767],
+    "shibuyaParco": [35.6605, 139.6983],
+    "takeshitaStreet": [35.6717, 139.7029],
+    "sunshine60": [35.7296, 139.7178],
+    "animateIkebukuro": [35.7317, 139.7153],
+    "akihabara": [35.6987, 139.7714],
+    "shimokitazawa": [35.6616, 139.6673],
+    "nakanoBroadway": [35.7075, 139.6659],
+    "kichijoji": [35.7033, 139.5795],
+    "roppongiMidtown": [35.6665, 139.7316],
+    "meguroRiver": [35.6416, 139.6973],
+    "blueCave": [35.659, 139.7004],
+    "kix": [34.4338, 135.2263],
+    "hirakatashi": [34.8165, 135.6477],
+    "usj": [34.6654, 135.4323]
+  },
+  "catalog": {
+    "activity": [
+      { "id": "act-flight-dxb-arrival", "city": "work", "label": "00:40 Arrive DXB (transit)", "locked": true },
+      { "id": "act-flight-dxb-kix", "city": "work", "label": "03:05 DXB → KIX (EK316)", "coord": "kix", "locked": true },
+      { "id": "act-arrive-kix", "city": "work", "label": "17:05 Arrive KIX", "coord": "kix", "locked": true },
+      { "id": "act-transfer-kix-hirakata", "city": "osaka", "label": "KIX → Hirakata (~90m)", "coord": "hirakatashi" },
+      { "id": "act-dinner-nana", "city": "osaka", "label": "Dinner with Nana (Hirakata)", "coord": "hirakatashi" },
+      { "id": "act-transfer-hirakata-kix", "city": "work", "label": "Hirakata → KIX", "coord": "kix" },
+      { "id": "act-flight-kix-dxb", "city": "work", "label": "23:10 KIX → DXB (EK317)", "coord": "kix", "locked": true },
+      { "id": "act-dotonbori-walk", "city": "osaka", "label": "Dōtonbori walk + street food", "coord": "dotonbori" },
+      { "id": "act-umeda-sky", "city": "osaka", "label": "Umeda Sky Building sunset", "coord": "umedaSky" },
+      { "id": "act-abeno-harukas", "city": "osaka", "label": "Abeno HARUKAS 300 view", "coord": "abenoHarukas" },
+      { "id": "act-kuromon-breakfast", "city": "osaka", "label": "Kuromon Market breakfast crawl", "coord": "kuromonMarket" },
+      { "id": "act-nakazakicho-morning", "city": "osaka", "label": "Nakazakichō slow morning (cafes & vintage)", "coord": "nakazakicho" },
+      { "id": "act-kaiyukan-aquarium", "city": "osaka", "label": "Osaka Aquarium Kaiyukan", "coord": "kaiyukan" },
+      { "id": "act-german-xmas-market", "city": "osaka", "label": "Osaka German Christmas Market (Umeda)", "coord": "osakaGermanMarket" },
+      { "id": "act-teamlab-botanical", "city": "osaka", "label": "teamLab Botanical Garden Osaka night walk", "coord": "nagaiBotanical" },
+      { "id": "act-usj-day", "city": "osaka", "label": "Universal Studios Japan day", "coord": "usj" },
+      { "id": "act-karaoke-namba", "city": "osaka", "label": "Namba karaoke & late izakaya", "coord": "dotonbori" },
+      { "id": "act-arashiyama", "city": "kyoto", "label": "Arashiyama bamboo grove & river", "coord": "arashiyama" },
+      { "id": "act-kiyomizudera", "city": "kyoto", "label": "Kiyomizu-dera & Sannenzaka", "coord": "kiyomizudera" },
+      { "id": "act-fushimi-inari", "city": "kyoto", "label": "Fushimi Inari at dusk", "coord": "fushimiInari" },
+      { "id": "act-philosophers-path", "city": "kyoto", "label": "Philosopher's Path & Higashiyama cafes", "coord": "philosophersPath" },
+      { "id": "act-uji-tea", "city": "kyoto", "label": "Uji tea tastings & Byōdō-in stroll", "coord": "uji" },
+      { "id": "act-nara-park", "city": "kyoto", "label": "Nara Park deer + Tōdai-ji", "coord": "naraPark" },
+      { "id": "act-koyasan-okunoin", "city": "kyoto", "label": "Kōyasan Okunoin night walk", "coord": "okunoin" },
+      { "id": "act-kurama-kibune", "city": "kyoto", "label": "Kurama → Kibune mountain walk", "coord": "kurama" },
+      { "id": "act-toei-studio", "city": "kyoto", "label": "Toei Kyoto Studio Park cosplay day", "coord": "toeiKyoto" },
+      { "id": "act-easy-kawaramachi", "city": "kyoto", "label": "Kawaramachi shopping & dessert crawl", "coord": "kiyomizudera" },
+      { "id": "act-arima-onsen", "city": "kobe", "label": "Arima Onsen golden & silver baths", "coord": "arimaOnsen" },
+      { "id": "act-himeji-castle", "city": "kobe", "label": "Himeji Castle + Kōko-en", "coord": "himejiCastle" },
+      { "id": "act-harborland-night", "city": "kobe", "label": "Kobe Harborland evening lights", "coord": "harborland" },
+      { "id": "act-kitano-ijinkan", "city": "kobe", "label": "Kobe Kitano Ijinkan & cafes", "coord": "kitanoIjinkan" },
+      { "id": "act-disney-day", "city": "tokyo", "label": "Tokyo Disney day (Sea/Land)", "coord": "disneyResort" },
+      { "id": "act-teamlab-planets", "city": "tokyo", "label": "teamLab Planets experience", "coord": "teamlabPlanets" },
+      { "id": "act-teamlab-borderless", "city": "tokyo", "label": "teamLab Borderless (Azabudai Hills)", "coord": "teamlabBorderless" },
+      { "id": "act-ghibli-museum", "city": "tokyo", "label": "Ghibli Museum (Mitaka)", "coord": "ghibliMuseum" },
+      { "id": "act-odaiba-day", "city": "tokyo", "label": "Odaiba DiverCity & Statue walk", "coord": "odaiba" },
+      { "id": "act-nakano-broadway", "city": "tokyo", "label": "Nakano Broadway treasure hunt", "coord": "nakanoBroadway" },
+      { "id": "act-shimokita-vintage", "city": "tokyo", "label": "Shimokitazawa thrift & coffee", "coord": "shimokitazawa" },
+      { "id": "act-kichijoji-day", "city": "tokyo", "label": "Kichijōji & Inokashira stroll", "coord": "kichijoji" },
+      { "id": "act-collab-cafe", "city": "tokyo", "label": "Collab café crawl (Animate/SQEX)", "coord": "sunshine60" },
+      { "id": "act-shibuya-scramble", "city": "tokyo", "label": "Shibuya scramble + PARCO run", "coord": "shibuyaParco" },
+      { "id": "act-harajuku-fashion", "city": "tokyo", "label": "Harajuku fashion lanes", "coord": "takeshitaStreet" },
+      { "id": "act-ikebukuro-day", "city": "tokyo", "label": "Ikebukuro Sunshine & otaku stops", "coord": "sunshine60" },
+      { "id": "act-karaoke-friends", "city": "tokyo", "label": "Late karaoke & izakaya with crew", "coord": "shibuyaParco" }
+    ],
+    "guide": [
+      { "id": "guide-donki-night-run", "city": "osaka", "label": "Donki night run (Dōtonbori)", "coord": "dotonbori" },
+      { "id": "guide-midosuji-lights", "city": "osaka", "label": "Midosuji Illumination highlights", "coord": "midosujiIllumination" },
+      { "id": "guide-german-market", "city": "osaka", "label": "Umeda German Christmas Market picks", "coord": "osakaGermanMarket" },
+      { "id": "guide-kimono-stroll", "city": "kyoto", "label": "Kimono stroll photo spot", "coord": "kiyomizudera" },
+      { "id": "guide-kiyomizu-lightup", "city": "kyoto", "label": "Kiyomizu-dera night illumination tips", "coord": "kiyomizudera" },
+      { "id": "guide-eikando-lightup", "city": "kyoto", "label": "Eikando maple light-up route", "coord": "eikando" },
+      { "id": "guide-rurikoin-autumn", "city": "kyoto", "label": "Rurikō-in garden reflection window", "coord": "rurikoin" },
+      { "id": "guide-nara-night", "city": "kyoto", "label": "Nara lantern evening stroll", "coord": "naraPark" },
+      { "id": "guide-harborland-shops", "city": "kobe", "label": "Harborland harbor cruise & sweets", "coord": "harborland" },
+      { "id": "guide-disney-strategy", "city": "tokyo", "label": "Tokyo Disney quick-start strategy", "coord": "disneyResort" },
+      { "id": "guide-shibuya-sky", "city": "tokyo", "label": "Shibuya SKY (observation deck)", "coord": "shibuyaParco" },
+      { "id": "guide-omotesando-cafes", "city": "tokyo", "label": "Omotesandō cafés & boutiques", "coord": "takeshitaStreet" },
+      { "id": "guide-nintendo-parco", "city": "tokyo", "label": "Nintendo Tokyo & Pokémon Center", "coord": "shibuyaParco" },
+      { "id": "guide-animate-ikebukuro", "city": "tokyo", "label": "Animate Ikebukuro flagship", "coord": "animateIkebukuro" },
+      { "id": "guide-akihabara-arcades", "city": "tokyo", "label": "Akihabara retro arcades crawl", "coord": "akihabara" },
+      { "id": "guide-harajuku-vintage", "city": "tokyo", "label": "Harajuku thrift & vintage run", "coord": "harajukuVintage" },
+      { "id": "guide-roppongi-illumination", "city": "tokyo", "label": "Tokyo Midtown illumination walk", "coord": "roppongiMidtown" },
+      { "id": "guide-meguro-river", "city": "tokyo", "label": "Meguro River light-up & cafes", "coord": "meguroRiver" },
+      { "id": "guide-blue-cave", "city": "tokyo", "label": "Shibuya Ao no Dokutsu route", "coord": "blueCave" }
+    ],
+    "stay": [
+      { "id": "stay-candeo-hirakata", "city": "osaka", "label": "Candeo Hotels Osaka Hirakata", "url": "https://www.candeohotels.com/en/osaka-hirakata/" },
+      { "id": "stay-sunplaza-hirakata", "city": "osaka", "label": "Hirakata SunPlaza Hotel", "url": "https://sunplazahotel.co.jp/en/" },
+      { "id": "stay-cross-hotel-osaka", "city": "osaka", "label": "Cross Hotel Osaka", "url": "https://www.crosshotel.com/osaka/en/" },
+      { "id": "stay-hankyu-respire", "city": "osaka", "label": "Hotel Hankyu RESPIRE Osaka", "url": "https://www.hankyu-hotel.com/en/hotel/respire" },
+      { "id": "stay-the-thousand-kyoto", "city": "kyoto", "label": "THE THOUSAND KYOTO", "url": "https://www.keihanhotels-resorts.co.jp/the-thousand-kyoto/en/" },
+      { "id": "stay-hotel-granvia-kyoto", "city": "kyoto", "label": "Hotel Granvia Kyoto", "url": "https://www.granviakyoto.com/" },
+      { "id": "stay-ekoin-koyasan", "city": "kyoto", "label": "Kōyasan Eko-in temple stay", "url": "https://www.ekoin.jp/en/" },
+      { "id": "stay-hotel-kanra", "city": "kyoto", "label": "Hotel Kanra Kyoto", "url": "https://www.hotelkanra.jp/en/" },
+      { "id": "stay-arima-grand", "city": "kobe", "label": "Arima Grand Hotel", "url": "https://www.arima-gh.jp/en/" },
+      { "id": "stay-la-suite-kobe", "city": "kobe", "label": "Hotel La Suite Kobe Harborland", "url": "https://www.l-s.jp/english/" },
+      { "id": "stay-oriental-hotel-kobe", "city": "kobe", "label": "Oriental Hotel Kobe", "url": "https://www.orientalhotel.jp/en/" },
+      { "id": "stay-mitsui-garden-otemachi", "city": "tokyo", "label": "Mitsui Garden Hotel Otemachi", "url": "https://www.gardenhotels.co.jp/otemachi/eng/" },
+      { "id": "stay-hotel-niwa-tokyo", "city": "tokyo", "label": "Hotel Niwa Tokyo", "url": "https://www.hotelniwa.jp/en/" },
+      { "id": "stay-park-hotel-tokyo", "city": "tokyo", "label": "Park Hotel Tokyo", "url": "https://parkhoteltokyo.com/" },
+      { "id": "stay-shinjuku-granbell", "city": "tokyo", "label": "Shinjuku Granbell Hotel", "url": "https://www.granbellhotel.jp/en/shinjuku/" },
+      { "id": "stay-airbnb-tokyo", "city": "tokyo", "label": "Airbnb — central Tokyo flat", "url": "https://www.airbnb.com/s/Tokyo--Japan/homes" },
+      { "id": "stay-disney-ambassador", "city": "tokyo", "label": "Disney Ambassador Hotel", "url": "https://www.tokyodisneyresort.jp/en/hotel/dh/" },
+      { "id": "stay-disneyland-hotel", "city": "tokyo", "label": "Tokyo Disneyland Hotel", "url": "https://www.tokyodisneyresort.jp/en/hotel/tdh/" },
+      { "id": "stay-disney-celebration", "city": "tokyo", "label": "Tokyo Disney Celebration Hotel", "url": "https://www.tokyodisneyresort.jp/en/hotel/dch/" }
+    ],
+    "booking": [
+      { "id": "book-usj", "city": "osaka", "label": "USJ + Super Nintendo World tickets", "url": "https://www.usj.co.jp/e/ticket/" },
+      { "id": "book-umeda-sky", "city": "osaka", "label": "Umeda Sky Building tickets", "url": "https://www.skybldg.co.jp/en/" },
+      { "id": "book-harukas", "city": "osaka", "label": "Abeno HARUKAS 300 observatory", "url": "https://www.abenoharukas-300.jp/en/" },
+      { "id": "book-midosuji-lights", "city": "osaka", "label": "Osaka Festival of the Lights info", "url": "https://www.hikari-kyoen.com/en/" },
+      { "id": "book-german-market", "city": "osaka", "label": "Osaka German Christmas Market details", "url": "https://www.skybldg.co.jp/event/xmas/" },
+      { "id": "book-mizuno", "city": "osaka", "label": "Okonomiyaki Mizuno reservations", "url": "https://www.gltjp.com/en/directory/item/12081/" },
+      { "id": "book-daruma", "city": "osaka", "label": "Kushikatsu Daruma (Shinsekai)", "url": "https://www.dotonbori.or.jp/en/shops/68" },
+      { "id": "book-teamlab-botanical", "city": "osaka", "label": "teamLab Botanical Garden Osaka", "url": "https://botanical.teamlab.art/" },
+      { "id": "book-sagano", "city": "kyoto", "label": "Sagano Romantic Train tickets", "url": "https://www.sagano-kanko.co.jp/en/ticket/" },
+      { "id": "book-kimono", "city": "kyoto", "label": "Kyoto kimono rental (Yumeyakata)", "url": "https://www.yumeyakata.com/" },
+      { "id": "book-tea-ceremony", "city": "kyoto", "label": "Camellia tea ceremony booking", "url": "https://www.tea-kyoto.com/" },
+      { "id": "book-kiyomizu-night", "city": "kyoto", "label": "Kiyomizu-dera night illumination", "url": "https://www.kiyomizudera.or.jp/en/event/" },
+      { "id": "book-eikando-night", "city": "kyoto", "label": "Eikando maple light-up details", "url": "https://eikando.or.jp/" },
+      { "id": "book-rurikoin", "city": "kyoto", "label": "Rurikō-in autumn visit info", "url": "https://rurikoin.komyoji.com/en/" },
+      { "id": "book-kurama-cable", "city": "kyoto", "label": "Kurama Cable Car & Onsen", "url": "https://www.kuruma-onsen.co.jp/" },
+      { "id": "book-himeji", "city": "kobe", "label": "Himeji Castle timed tickets", "url": "https://himejicastle.ntaticketing.com/" },
+      { "id": "book-kobe-ropeway", "city": "kobe", "label": "Kobe Nunobiki Ropeway", "url": "https://www.kobeherb.com/en/ropeway/" },
+      { "id": "book-arima-onsen", "city": "kobe", "label": "Arima Onsen ryokan reservations", "url": "https://visit.arima-onsen.com/en/hotel/" },
+      { "id": "book-teamlab-planets", "city": "tokyo", "label": "teamLab Planets tickets", "url": "https://teamlabplanets.dmm.com/en" },
+      { "id": "book-teamlab-borderless", "city": "tokyo", "label": "teamLab Borderless (Azabudai Hills)", "url": "https://www.teamlab.art/e/borderless/" },
+      { "id": "book-tokyo-disney", "city": "tokyo", "label": "Tokyo Disney Resort tickets", "url": "https://www.tokyodisneyresort.jp/en/ticket/" },
+      { "id": "book-ghibli", "city": "tokyo", "label": "Ghibli Museum via Lawson", "url": "https://l-tike.com/st1/ghibli-en/" },
+      { "id": "book-shibuya-sky", "city": "tokyo", "label": "Shibuya SKY admission", "url": "https://www.shibuya-scramble-square.com/en/sky/" },
+      { "id": "book-blue-cave", "city": "tokyo", "label": "Ao no Dokutsu (Blue Cave) info", "url": "https://bluecavetokyo.com/" },
+      { "id": "book-midtown-christmas", "city": "tokyo", "label": "Tokyo Midtown Christmas lights", "url": "https://www.tokyo-midtown.com/en/event/xmas/" },
+      { "id": "book-uogashi", "city": "tokyo", "label": "Standing sushi Uogashi (Shibuya)", "url": "https://www.timeout.com/tokyo/restaurants/uogashi-nihon-ichi-shibuya-dogenzaka" },
+      { "id": "book-gyukatsu", "city": "tokyo", "label": "Gyukatsu Motomura Harajuku", "url": "https://s.tabelog.com/en/tokyo/A1306/A130601/13208866/" },
+      { "id": "book-nakano-broadway", "city": "tokyo", "label": "Nakano Broadway floor guide", "url": "https://www.nbw.jp/en/" }
+    ]
+  },
+  "defaults": {
+    "2025-11-14": {
+      "loc": "work",
+      "theme": "Flights → Osaka",
+      "friends": ["Nana"],
+      "stay": null,
+      "slots": {
+        "morning": ["act-flight-dxb-arrival"],
+        "afternoon": ["act-flight-dxb-kix"],
+        "evening": ["act-arrive-kix", "act-transfer-kix-hirakata", "act-dinner-nana"]
+      },
+      "locks": {
+        "act-flight-dxb-arrival": 1,
+        "act-flight-dxb-kix": 1,
+        "act-arrive-kix": 1
+      }
+    },
+    "2025-11-15": {
+      "loc": "kyoto",
+      "theme": "Kyoto sights",
+      "friends": ["Nana"],
+      "stay": null,
+      "slots": {
+        "morning": ["act-arashiyama"],
+        "afternoon": ["act-kiyomizudera"],
+        "evening": ["act-fushimi-inari"]
+      },
+      "locks": {}
+    },
+    "2025-11-16": {
+      "loc": "kyoto",
+      "theme": "Nara or Uji",
+      "friends": ["Nana"],
+      "stay": null,
+      "slots": {
+        "morning": ["act-nara-park"],
+        "afternoon": ["act-uji-tea"],
+        "evening": []
+      },
+      "locks": {}
+    },
+    "2025-11-17": {
+      "loc": "kyoto",
+      "theme": "Kōyasan overnight",
+      "friends": ["Nana"],
+      "stay": "stay-ekoin-koyasan",
+      "slots": {
+        "morning": [],
+        "afternoon": ["act-koyasan-okunoin"],
+        "evening": ["act-koyasan-okunoin"]
+      },
+      "locks": {}
+    },
+    "2025-11-18": {
+      "loc": "work",
+      "theme": "Tue — Nana work",
+      "friends": ["Nana"],
+      "stay": null,
+      "slots": {
+        "morning": [],
+        "afternoon": [],
+        "evening": ["act-dotonbori-walk"]
+      },
+      "locks": {}
+    },
+    "2025-11-19": {
+      "loc": "kobe",
+      "theme": "Arima Onsen + Kobe night",
+      "friends": ["Nana"],
+      "stay": "stay-arima-grand",
+      "slots": {
+        "morning": ["act-arima-onsen"],
+        "afternoon": ["act-harborland-night"],
+        "evening": []
+      },
+      "locks": {}
+    },
+    "2025-11-20": {
+      "loc": "osaka",
+      "theme": "Umeda sunset + karaoke",
+      "friends": ["Nana"],
+      "stay": null,
+      "slots": {
+        "morning": [],
+        "afternoon": ["act-umeda-sky"],
+        "evening": ["act-karaoke-namba"]
+      },
+      "locks": {}
+    },
+    "2025-11-21": {
+      "loc": "work",
+      "theme": "Fri — Nana work",
+      "friends": ["Nana"],
+      "stay": null,
+      "slots": {
+        "morning": [],
+        "afternoon": [],
+        "evening": ["act-abeno-harukas"]
+      },
+      "locks": {}
+    },
+    "2025-11-22": {
+      "loc": "tokyo",
+      "theme": "Disney or teamLab",
+      "friends": ["Nana"],
+      "stay": "stay-disney-ambassador",
+      "slots": {
+        "morning": ["act-disney-day"],
+        "afternoon": ["act-disney-day"],
+        "evening": ["act-disney-day"]
+      },
+      "locks": {}
+    },
+    "2025-11-23": {
+      "loc": "tokyo",
+      "theme": "Nicole + Ken day",
+      "friends": ["Nicole", "Ken", "James"],
+      "stay": "stay-airbnb-tokyo",
+      "slots": {
+        "morning": ["act-teamlab-planets"],
+        "afternoon": ["act-collab-cafe"],
+        "evening": ["act-karaoke-friends"]
+      },
+      "locks": {}
+    },
+    "2025-11-24": {
+      "loc": "tokyo",
+      "theme": "Shibuya / Harajuku",
+      "friends": ["Nicole", "Ken", "James", "Phil"],
+      "stay": "stay-airbnb-tokyo",
+      "slots": {
+        "morning": ["act-shibuya-scramble"],
+        "afternoon": ["act-harajuku-fashion"],
+        "evening": ["act-ikebukuro-day"]
+      },
+      "locks": {}
+    },
+    "2025-11-25": {
+      "loc": "work",
+      "theme": "Tue — Travel/admin",
+      "friends": ["Nana"],
+      "stay": null,
+      "slots": {
+        "morning": [],
+        "afternoon": [],
+        "evening": []
+      },
+      "locks": {}
+    },
+    "2025-11-26": {
+      "loc": "kobe",
+      "theme": "Himeji Castle day",
+      "friends": [],
+      "stay": null,
+      "slots": {
+        "morning": ["act-himeji-castle"],
+        "afternoon": [],
+        "evening": []
+      },
+      "locks": {}
+    },
+    "2025-11-27": {
+      "loc": "kobe",
+      "theme": "Easy Kansai",
+      "friends": [],
+      "stay": null,
+      "slots": {
+        "morning": ["act-harborland-night"],
+        "afternoon": [],
+        "evening": []
+      },
+      "locks": {}
+    },
+    "2025-11-28": {
+      "loc": "osaka",
+      "theme": "Birthday in Osaka",
+      "friends": ["Nana", "Nicole", "Ken", "James"],
+      "stay": null,
+      "slots": {
+        "morning": [],
+        "afternoon": [],
+        "evening": ["act-karaoke-namba"]
+      },
+      "locks": {}
+    },
+    "2025-11-29": {
+      "loc": "kyoto",
+      "theme": "Leaves & tea",
+      "friends": ["Nana"],
+      "stay": null,
+      "slots": {
+        "morning": ["act-uji-tea"],
+        "afternoon": ["act-arashiyama"],
+        "evening": []
+      },
+      "locks": {}
+    },
+    "2025-11-30": {
+      "loc": "work",
+      "theme": "Fly home",
+      "friends": ["Nana"],
+      "stay": null,
+      "slots": {
+        "morning": ["act-transfer-hirakata-kix"],
+        "afternoon": [],
+        "evening": ["act-flight-kix-dxb"]
+      },
+      "locks": {
+        "act-flight-kix-dxb": 1
+      }
+    }
+  }
+}

--- a/index.html
+++ b/index.html
@@ -1,0 +1,196 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Japan Trip — Nov 14–30, 2025</title>
+    <link rel="stylesheet" href="styles.css" />
+    <link
+      rel="stylesheet"
+      href="https://unpkg.com/leaflet@1.9.4/dist/leaflet.css"
+      integrity="sha256-p4NxAoJBhIIN+hmNHrzRCf9tD/miZyoHS5obTRR9BMY="
+      crossorigin=""
+    />
+    <script
+      defer
+      src="https://unpkg.com/leaflet@1.9.4/dist/leaflet.js"
+      integrity="sha256-20nQCchB9co0qIjJZRGuk2/Z9VM+kNiyxNV1lvTlZBo="
+      crossorigin=""
+    ></script>
+    <script type="module" src="scripts/app.js" defer></script>
+  </head>
+  <body>
+    <header class="site-header">
+      <div class="header-inner">
+        <h1 class="site-title">Japan Trip — Nov 14–30, 2025</h1>
+        <div class="toolbar" role="toolbar" aria-label="Filters and actions">
+          <div class="toolbar-group">
+            <span class="toolbar-label">Show</span>
+            <button class="chip" data-filter="all" aria-pressed="true">All</button>
+          </div>
+          <div class="toolbar-group" id="friendFilters">
+            <span class="toolbar-label">Friends</span>
+            <button class="chip chip--friend" data-friend="Nana">Nana</button>
+            <button class="chip chip--friend" data-friend="Nicole">Nicole</button>
+            <button class="chip chip--friend" data-friend="Ken">Ken</button>
+            <button class="chip chip--friend" data-friend="James">James</button>
+            <button class="chip chip--friend" data-friend="Phil">Phil</button>
+          </div>
+          <div class="toolbar-group" id="locationFilters">
+            <span class="toolbar-label">Places</span>
+            <button class="chip chip--location" data-location="osaka">Osaka/Hirakata</button>
+            <button class="chip chip--location" data-location="kyoto">Kyoto/Nara/Kōyasan</button>
+            <button class="chip chip--location" data-location="tokyo">Tokyo/Chiba</button>
+            <button class="chip chip--location" data-location="kobe">Kobe/Arima/Himeji</button>
+            <button class="chip chip--location" data-location="work">Work/Travel</button>
+          </div>
+          <div class="toolbar-group toolbar-group--actions">
+            <button class="btn" data-action="toggle-edit">Edit</button>
+            <button class="btn" data-action="open-wizard">Trip setup</button>
+            <button class="btn" data-action="share-state">Share</button>
+            <button class="btn" data-action="save-github">Save to GitHub</button>
+            <button class="btn" data-action="export-ics">Export .ics</button>
+          </div>
+        </div>
+        <div class="filter-feedback" id="filterFeedback" aria-live="polite"></div>
+        <div class="legend" aria-label="Color legend">
+          <div class="legend-item"><span class="legend-swatch" data-swatch="osaka"></span>Osaka/Hirakata</div>
+          <div class="legend-item"><span class="legend-swatch" data-swatch="kyoto"></span>Kyoto/Nara/Kōyasan</div>
+          <div class="legend-item"><span class="legend-swatch" data-swatch="tokyo"></span>Tokyo/Chiba</div>
+          <div class="legend-item"><span class="legend-swatch" data-swatch="kobe"></span>Kobe/Arima/Himeji</div>
+          <div class="legend-item"><span class="legend-swatch" data-swatch="work"></span>Work/Travel</div>
+        </div>
+      </div>
+    </header>
+    <main class="main">
+      <div id="readonlyBanner" class="banner banner--readonly" hidden>Read-only share link — editing disabled.</div>
+      <section id="pool" class="idea-pool" aria-label="Activity pool" hidden>
+        <header class="idea-pool__header">
+          <h2>Idea pool</h2>
+          <p class="idea-pool__hint">Drag saved activities into any day. Remove to declutter.</p>
+        </header>
+        <div id="poolChips" class="idea-pool__chips"></div>
+        <button class="btn btn--subtle" data-action="clear-pool">Clear pool</button>
+      </section>
+      <section id="calendar" class="calendar" role="grid" aria-label="Trip plan"></section>
+    </main>
+
+    <div id="sheetBackdrop" class="sheet-backdrop" aria-hidden="true"></div>
+    <aside id="sheet" class="sheet" aria-hidden="true" role="dialog" aria-modal="true">
+      <div class="sheet__header">
+        <div>
+          <p class="sheet__subtitle" id="sheetSubtitle"></p>
+          <h2 class="sheet__title" id="sheetTitle">Add to day</h2>
+        </div>
+        <button class="btn btn--subtle" data-action="close-sheet">Close</button>
+      </div>
+      <div class="sheet__tabs" role="tablist">
+        <button class="tab" role="tab" aria-selected="true" data-tab="activity">Activities</button>
+        <button class="tab" role="tab" aria-selected="false" data-tab="stay">Stays</button>
+        <button class="tab" role="tab" aria-selected="false" data-tab="booking">Bookings</button>
+      </div>
+      <div class="sheet__body" id="sheetBody"></div>
+    </aside>
+
+    <div id="mapOverlay" class="overlay" aria-hidden="true">
+      <div class="overlay__dialog" role="dialog" aria-modal="true" aria-labelledby="mapTitle">
+        <div class="overlay__header">
+          <h2 class="overlay__title" id="mapTitle">Day map</h2>
+          <button class="btn btn--subtle" data-action="close-map">Close</button>
+        </div>
+        <div id="map" class="overlay__map" role="presentation"></div>
+      </div>
+    </div>
+
+    <div id="wizardOverlay" class="wizard-overlay" aria-hidden="true">
+      <div class="wizard" role="dialog" aria-modal="true" aria-labelledby="wizardTitle">
+        <header class="wizard__header">
+          <div>
+            <p class="wizard__eyebrow">Trip bootstrap</p>
+            <h2 class="wizard__title" id="wizardTitle">Set up your trip</h2>
+          </div>
+          <button class="btn btn--subtle" data-action="close-wizard">Close</button>
+        </header>
+        <form class="wizard__form" id="wizardForm">
+          <div class="wizard__field">
+            <label for="wizardTitleInput">Trip title</label>
+            <input id="wizardTitleInput" name="title" type="text" required />
+          </div>
+          <div class="wizard__row">
+            <div class="wizard__field">
+              <label for="wizardStart">Start date</label>
+              <input id="wizardStart" name="start" type="date" required />
+            </div>
+            <div class="wizard__field">
+              <label for="wizardEnd">End date</label>
+              <input id="wizardEnd" name="end" type="date" required />
+            </div>
+          </div>
+          <div class="wizard__field">
+            <label for="wizardBase">Base location</label>
+            <select id="wizardBase" name="base" required></select>
+          </div>
+          <div class="wizard__field">
+            <label for="wizardPeople">People (comma separated)</label>
+            <textarea id="wizardPeople" name="people" rows="2"></textarea>
+            <p class="wizard__hint">Existing colors stay put — new names use calm defaults.</p>
+          </div>
+          <fieldset class="wizard__fieldset">
+            <legend>Availability constraints</legend>
+            <label class="wizard__checkbox">
+              <input type="checkbox" name="nanaWork" id="wizardNanaWork" />
+              <span>Flag Nana weekdays (Tue/Fri) when far from base</span>
+            </label>
+            <label class="wizard__field wizard__field--inline" for="wizardMaxAway">Max consecutive nights away for Nana</label>
+            <input id="wizardMaxAway" name="maxAway" type="number" min="1" max="10" step="1" value="3" />
+          </fieldset>
+          <div class="wizard__actions">
+            <button type="submit" class="btn">Save setup</button>
+          </div>
+        </form>
+      </div>
+    </div>
+
+    <div id="githubOverlay" class="wizard-overlay" aria-hidden="true">
+      <div class="wizard" role="dialog" aria-modal="true" aria-labelledby="githubTitle">
+        <header class="wizard__header">
+          <div>
+            <p class="wizard__eyebrow">Persist to GitHub</p>
+            <h2 class="wizard__title" id="githubTitle">Save trip.json</h2>
+          </div>
+          <button class="btn btn--subtle" data-action="close-github">Close</button>
+        </header>
+        <form class="wizard__form" id="githubForm">
+          <div class="wizard__field">
+            <label for="githubOwner">Owner / org</label>
+            <input id="githubOwner" name="owner" type="text" required />
+          </div>
+          <div class="wizard__field">
+            <label for="githubRepo">Repository</label>
+            <input id="githubRepo" name="repo" type="text" required />
+          </div>
+          <div class="wizard__field">
+            <label for="githubBranch">Branch</label>
+            <input id="githubBranch" name="branch" type="text" value="main" />
+          </div>
+          <div class="wizard__field">
+            <label for="githubPath">Path</label>
+            <input id="githubPath" name="path" type="text" value="data/trip.json" />
+          </div>
+          <div class="wizard__field">
+            <label for="githubToken">Personal access token</label>
+            <input id="githubToken" name="token" type="password" autocomplete="off" required />
+            <p class="wizard__hint">Needs <code>repo</code> scope. Stored only for this session.</p>
+          </div>
+          <div class="wizard__field">
+            <label for="githubMessage">Commit message</label>
+            <input id="githubMessage" name="message" type="text" value="Update trip definition" />
+          </div>
+          <div class="wizard__actions">
+            <button type="submit" class="btn">Push update</button>
+          </div>
+        </form>
+      </div>
+    </div>
+  </body>
+</html>

--- a/scripts/app.js
+++ b/scripts/app.js
@@ -1,0 +1,1954 @@
+import {
+  fetchTripDefinition,
+  buildStorageKey,
+  saveTripDefinitionToGitHub,
+  encodeBase64,
+} from './data.js';
+
+const SHARE_PREFIX = '#view=';
+const COARSE_POINTER = window.matchMedia('(pointer: coarse)').matches;
+const FALLBACK_COLORS = ['#fde68a', '#bbf7d0', '#bae6fd', '#c7d2fe', '#fecdd3', '#fbcfe8'];
+const TRAVEL_SPEED_KMH = 40;
+
+const calendarEl = document.getElementById('calendar');
+const poolSection = document.getElementById('pool');
+const poolChipsEl = document.getElementById('poolChips');
+const filterFeedbackEl = document.getElementById('filterFeedback');
+const readonlyBanner = document.getElementById('readonlyBanner');
+const friendFiltersEl = document.getElementById('friendFilters');
+const locationFiltersEl = document.getElementById('locationFilters');
+const editBtn = document.querySelector('[data-action="toggle-edit"]');
+const shareBtn = document.querySelector('[data-action="share-state"]');
+const wizardBtn = document.querySelector('[data-action="open-wizard"]');
+const saveGithubBtn = document.querySelector('[data-action="save-github"]');
+const icsBtn = document.querySelector('[data-action="export-ics"]');
+const clearPoolBtn = poolSection.querySelector('[data-action="clear-pool"]');
+const allFilterBtn = document.querySelector('[data-filter="all"]');
+
+const sheetEl = document.getElementById('sheet');
+const sheetBackdrop = document.getElementById('sheetBackdrop');
+const sheetTitle = document.getElementById('sheetTitle');
+const sheetSubtitle = document.getElementById('sheetSubtitle');
+const sheetBody = document.getElementById('sheetBody');
+
+const mapOverlay = document.getElementById('mapOverlay');
+const closeMapBtn = mapOverlay.querySelector('[data-action="close-map"]');
+
+const wizardOverlay = document.getElementById('wizardOverlay');
+const wizardForm = document.getElementById('wizardForm');
+const closeWizardBtn = wizardOverlay.querySelector('[data-action="close-wizard"]');
+const githubOverlay = document.getElementById('githubOverlay');
+const githubForm = document.getElementById('githubForm');
+const closeGithubBtn = githubOverlay.querySelector('[data-action="close-github"]');
+
+let statusTimer = null;
+
+const state = {
+  definition: null,
+  storageKey: '',
+  editing: false,
+  share: { readOnly: false },
+  filter: { friends: new Set(), locations: new Set() },
+  sheet: { open: false, day: null, slot: 'morning', tab: 'activity' },
+  plan: { days: {}, pool: [] },
+  catalog: { activity: [], guide: [], stay: [], booking: [] },
+  customCatalog: { activity: [], guide: [], stay: [], booking: [] },
+  customCoordinates: {},
+  coordinates: {},
+  themes: {},
+  people: [],
+  locations: [],
+  locationOrder: [],
+  dateSequence: [],
+  availability: new Map(),
+  travelCache: new Map(),
+  pointerDrag: null,
+  chipDragData: null,
+  cardDragSource: null,
+  message: '',
+  userConfig: {
+    title: 'Trip plan',
+    range: { start: '', end: '' },
+    baseLocation: 'work',
+    constraints: { nanaWork: true, maxAway: 3 },
+    people: [],
+  },
+  map: { instance: null, markers: null, route: null },
+};
+
+init();
+
+async function init() {
+  try {
+    state.definition = await fetchTripDefinition();
+  } catch (error) {
+    console.error('Unable to load trip definition', error);
+    setStatusMessage('Failed to load trip data.', 'error');
+    return;
+  }
+
+  state.storageKey = buildStorageKey(state.definition);
+  applyDefinitionDefaults();
+  loadLocalState();
+  rebuildDerivedData();
+
+  const shared = loadFromHash();
+  if (!shared) {
+    ensurePlanForRange();
+    rebuildDerivedData();
+    persistState();
+  }
+
+  renderApp();
+  attachGlobalEvents();
+
+  if (!shared && shouldOpenWizardInitially()) {
+    openWizard();
+  }
+}
+
+function applyDefinitionDefaults() {
+  const def = state.definition;
+  state.locations = Array.isArray(def.locations) ? def.locations.map((loc) => ({ ...loc })) : [];
+  state.locationOrder = state.locations.map((loc) => loc.id);
+  state.coordinates = { ...(def.coordinates || {}) };
+  state.themes = { ...(def.themes || {}) };
+  state.catalog = {
+    activity: Array.isArray(def.catalog?.activity) ? def.catalog.activity.map((item) => ({ ...item })) : [],
+    guide: Array.isArray(def.catalog?.guide) ? def.catalog.guide.map((item) => ({ ...item })) : [],
+    stay: Array.isArray(def.catalog?.stay) ? def.catalog.stay.map((item) => ({ ...item })) : [],
+    booking: Array.isArray(def.catalog?.booking) ? def.catalog.booking.map((item) => ({ ...item })) : [],
+  };
+  const basePeople = Array.isArray(def.people) ? def.people.map((person) => ({ ...person })) : [];
+  state.userConfig.title = def.trip?.title || state.userConfig.title;
+  state.userConfig.range = {
+    start: def.trip?.range?.start || new Date().toISOString().slice(0, 10),
+    end: def.trip?.range?.end || new Date().toISOString().slice(0, 10),
+  };
+  state.userConfig.baseLocation = def.trip?.baseLocation || state.userConfig.baseLocation;
+  const nanaDefaults = def.people?.find((p) => p.id === 'Nana')?.constraints || {};
+  state.userConfig.constraints = {
+    nanaWork: def.constraints?.nanaWork ?? (nanaDefaults.workDays ? true : true),
+    maxAway: def.constraints?.maxAway ?? nanaDefaults.maxAway ?? 3,
+  };
+  state.userConfig.people = basePeople.map((person) => ({
+    id: person.id,
+    label: person.label || person.id,
+    color: person.color,
+  }));
+  syncPeople();
+  buildDateSequenceForRange();
+}
+
+function shouldOpenWizardInitially() {
+  const stored = localStorage.getItem(state.storageKey);
+  return !stored;
+}
+
+function loadLocalState() {
+  try {
+    const raw = localStorage.getItem(state.storageKey);
+    if (!raw) return;
+    const parsed = JSON.parse(raw);
+    if (parsed?.userConfig) {
+      const cfg = parsed.userConfig;
+      state.userConfig.title = cfg.title || state.userConfig.title;
+      if (cfg.range?.start && cfg.range?.end) {
+        state.userConfig.range = { start: cfg.range.start, end: cfg.range.end };
+      }
+      if (cfg.baseLocation) state.userConfig.baseLocation = cfg.baseLocation;
+      if (cfg.constraints) {
+        state.userConfig.constraints = {
+          nanaWork: cfg.constraints.nanaWork ?? state.userConfig.constraints.nanaWork,
+          maxAway: cfg.constraints.maxAway ?? state.userConfig.constraints.maxAway,
+        };
+      }
+      if (Array.isArray(cfg.people) && cfg.people.length) {
+        state.userConfig.people = cfg.people.map((person) => ({
+          id: person.id,
+          label: person.label || person.id,
+          color: person.color,
+        }));
+      }
+    }
+    syncPeople();
+    buildDateSequenceForRange();
+
+    if (parsed?.customCatalog) {
+      state.customCatalog = {
+        activity: Array.isArray(parsed.customCatalog.activity) ? parsed.customCatalog.activity.map((item) => ({ ...item })) : [],
+        guide: Array.isArray(parsed.customCatalog.guide) ? parsed.customCatalog.guide.map((item) => ({ ...item })) : [],
+        stay: Array.isArray(parsed.customCatalog.stay) ? parsed.customCatalog.stay.map((item) => ({ ...item })) : [],
+        booking: Array.isArray(parsed.customCatalog.booking) ? parsed.customCatalog.booking.map((item) => ({ ...item })) : [],
+      };
+    }
+    if (parsed?.customCoordinates) {
+      state.customCoordinates = { ...parsed.customCoordinates };
+    }
+    state.plan.pool = Array.isArray(parsed?.pool) ? [...parsed.pool] : [];
+    state.plan.days = parsed?.days ? { ...parsed.days } : {};
+  } catch (error) {
+    console.warn('Failed to load saved state', error);
+  }
+}
+
+function persistState() {
+  if (state.share.readOnly) return;
+  try {
+    const payload = {
+      version: state.definition.version,
+      days: state.plan.days,
+      pool: state.plan.pool,
+      customCatalog: state.customCatalog,
+      customCoordinates: state.customCoordinates,
+      userConfig: state.userConfig,
+    };
+    localStorage.setItem(state.storageKey, JSON.stringify(payload));
+  } catch (error) {
+    console.warn('Unable to persist trip planner state', error);
+  }
+}
+
+function syncPeople() {
+  const combined = new Map();
+  const addPerson = (person) => {
+    if (!person || !person.id) return;
+    if (!combined.has(person.id)) {
+      combined.set(person.id, {
+        id: person.id,
+        label: person.label || person.id,
+        color: person.color || pickFallbackColor(combined.size),
+      });
+    }
+  };
+  (state.definition.people || []).forEach(addPerson);
+  (state.userConfig.people || []).forEach(addPerson);
+  state.people = Array.from(combined.values());
+  state.userConfig.people = state.people.map((person) => ({ ...person }));
+}
+
+function pickFallbackColor(index) {
+  return FALLBACK_COLORS[index % FALLBACK_COLORS.length];
+}
+
+function buildDateSequenceForRange() {
+  state.dateSequence = buildDateSequence(state.userConfig.range.start, state.userConfig.range.end);
+}
+
+function ensurePlanForRange() {
+  const defaults = state.definition.defaults || {};
+  const nextDays = {};
+  state.dateSequence.forEach((dateKey) => {
+    const merged = mergeDayData(defaults[dateKey], state.plan.days?.[dateKey]);
+    nextDays[dateKey] = merged;
+  });
+  state.plan.days = nextDays;
+  pruneTravelCache();
+}
+
+function pruneTravelCache() {
+  const next = new Map();
+  state.dateSequence.forEach((date) => {
+    if (state.travelCache.has(date)) {
+      next.set(date, state.travelCache.get(date));
+    }
+  });
+  state.travelCache = next;
+}
+
+function buildDateSequence(start, end) {
+  const results = [];
+  if (!start || !end) return results;
+  const startDate = new Date(`${start}T00:00:00`);
+  const endDate = new Date(`${end}T00:00:00`);
+  if (Number.isNaN(startDate.getTime()) || Number.isNaN(endDate.getTime())) return results;
+  for (let cursor = new Date(startDate); cursor <= endDate; cursor.setDate(cursor.getDate() + 1)) {
+    results.push(cursor.toISOString().slice(0, 10));
+  }
+  return results;
+}
+
+function createEmptyDay(location = state.userConfig.baseLocation || 'work') {
+  return {
+    loc: location,
+    theme: '',
+    friends: [],
+    stay: null,
+    slots: { morning: [], afternoon: [], evening: [] },
+    locks: {},
+  };
+}
+
+function cloneDay(day) {
+  const source = day || createEmptyDay();
+  return {
+    loc: source.loc || state.userConfig.baseLocation || 'work',
+    theme: source.theme || '',
+    friends: Array.isArray(source.friends) ? [...new Set(source.friends.filter(Boolean))] : [],
+    stay: source.stay || null,
+    slots: {
+      morning: Array.isArray(source.slots?.morning) ? [...source.slots.morning] : [],
+      afternoon: Array.isArray(source.slots?.afternoon) ? [...source.slots.afternoon] : [],
+      evening: Array.isArray(source.slots?.evening) ? [...source.slots.evening] : [],
+    },
+    locks: { ...(source.locks || {}) },
+  };
+}
+
+function mergeDayData(defaultDay, savedDay) {
+  if (!savedDay) return cloneDay(defaultDay || createEmptyDay());
+  const merged = cloneDay(defaultDay || createEmptyDay());
+  merged.loc = savedDay.loc || merged.loc;
+  merged.theme = savedDay.theme ?? merged.theme;
+  merged.stay = savedDay.stay ?? merged.stay ?? null;
+  if (Array.isArray(savedDay.friends)) {
+    merged.friends = [...new Set(savedDay.friends.filter(Boolean))];
+  }
+  ['morning', 'afternoon', 'evening'].forEach((slot) => {
+    if (Array.isArray(savedDay.slots?.[slot])) {
+      merged.slots[slot] = [...savedDay.slots[slot]];
+    }
+  });
+  merged.locks = { ...merged.locks, ...(savedDay.locks || {}) };
+  return merged;
+}
+function rebuildDerivedData() {
+  state.coordinates = { ...(state.definition.coordinates || {}), ...state.customCoordinates };
+  state.catalog.activity = mergeCatalogArrays(state.definition.catalog?.activity, state.customCatalog.activity);
+  state.catalog.guide = mergeCatalogArrays(state.definition.catalog?.guide, state.customCatalog.guide);
+  state.catalog.stay = mergeCatalogArrays(state.definition.catalog?.stay, state.customCatalog.stay);
+  state.catalog.booking = mergeCatalogArrays(state.definition.catalog?.booking, state.customCatalog.booking);
+  updateTravelCache();
+  updateAvailabilityWarnings();
+}
+
+function mergeCatalogArrays(base = [], extra = []) {
+  const map = new Map();
+  base.forEach((item) => {
+    if (item?.id) {
+      map.set(item.id, { ...item });
+    }
+  });
+  extra.forEach((item) => {
+    if (item?.id) {
+      map.set(item.id, { ...item });
+    }
+  });
+  return Array.from(map.values());
+}
+
+function ensureDay(dateKey) {
+  if (!state.plan.days[dateKey]) {
+    state.plan.days[dateKey] = createEmptyDay();
+  }
+  const day = state.plan.days[dateKey];
+  day.slots = day.slots || { morning: [], afternoon: [], evening: [] };
+  day.locks = day.locks || {};
+  day.friends = Array.isArray(day.friends) ? day.friends : [];
+  day.loc = day.loc || state.userConfig.baseLocation || 'work';
+  return day;
+}
+
+function renderApp() {
+  updateDocumentTitle();
+  renderFilterChips();
+  renderPool();
+  renderCalendar();
+  syncFilterButtons();
+  updateFilterFeedback();
+  updateActionStates();
+}
+
+function updateDocumentTitle() {
+  const heading = document.querySelector('.site-title');
+  if (heading) heading.textContent = state.userConfig.title;
+  document.title = state.userConfig.title;
+}
+
+function renderFilterChips() {
+  if (friendFiltersEl) {
+    friendFiltersEl.innerHTML = '';
+    const label = document.createElement('span');
+    label.className = 'toolbar-label';
+    label.textContent = 'Friends';
+    friendFiltersEl.appendChild(label);
+    state.people.forEach((person) => {
+      const btn = document.createElement('button');
+      btn.className = 'chip chip--friend';
+      btn.dataset.friend = person.id;
+      btn.textContent = person.label || person.id;
+      if (person.color) {
+        btn.style.background = person.color;
+      }
+      btn.addEventListener('click', () => toggleFriendFilter(person.id));
+      friendFiltersEl.appendChild(btn);
+    });
+  }
+
+  if (locationFiltersEl) {
+    locationFiltersEl.innerHTML = '';
+    const label = document.createElement('span');
+    label.className = 'toolbar-label';
+    label.textContent = 'Places';
+    locationFiltersEl.appendChild(label);
+    state.locationOrder.forEach((locId) => {
+      const meta = state.locations.find((loc) => loc.id === locId);
+      if (!meta) return;
+      const btn = document.createElement('button');
+      btn.className = 'chip chip--location';
+      btn.dataset.location = locId;
+      btn.textContent = meta.label || locId;
+      btn.addEventListener('click', () => toggleLocationFilter(locId));
+      locationFiltersEl.appendChild(btn);
+    });
+  }
+}
+
+function toggleFriendFilter(friend) {
+  if (state.filter.friends.has(friend)) {
+    state.filter.friends.delete(friend);
+  } else {
+    state.filter.friends.add(friend);
+  }
+  applyFilters();
+  syncFilterButtons();
+  updateFilterFeedback();
+}
+
+function toggleLocationFilter(location) {
+  if (state.filter.locations.has(location)) {
+    state.filter.locations.delete(location);
+  } else {
+    state.filter.locations.add(location);
+  }
+  applyFilters();
+  syncFilterButtons();
+  updateFilterFeedback();
+}
+
+function clearFilters() {
+  state.filter.friends.clear();
+  state.filter.locations.clear();
+  applyFilters();
+  syncFilterButtons();
+  updateFilterFeedback();
+}
+
+function renderPool() {
+  poolChipsEl.innerHTML = '';
+  const poolItems = state.plan.pool.filter(Boolean);
+  poolSection.hidden = !poolItems.length;
+  if (!poolItems.length) return;
+
+  poolItems.forEach((id, index) => {
+    const item = getActivityById(id) || getGuideById(id);
+    const chip = document.createElement('span');
+    chip.className = 'chiplet';
+    chip.dataset.id = id;
+    chip.dataset.source = 'pool';
+    chip.dataset.index = String(index);
+    chip.appendChild(buildChipContent(item?.label || id));
+    if (state.editing && !state.share.readOnly) {
+      chip.draggable = !COARSE_POINTER;
+      chip.addEventListener('dragstart', handleChipDragStart);
+      chip.addEventListener('dragend', handleChipDragEnd);
+      chip.addEventListener('pointerdown', handleChipPointerDown);
+      const actions = document.createElement('span');
+      actions.className = 'chiplet__actions';
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'chiplet__btn';
+      removeBtn.textContent = '✕';
+      removeBtn.title = 'Remove from pool';
+      removeBtn.addEventListener('click', () => removeFromPool(index));
+      actions.appendChild(removeBtn);
+      chip.appendChild(actions);
+    }
+    poolChipsEl.appendChild(chip);
+  });
+}
+
+function renderCalendar() {
+  calendarEl.innerHTML = '';
+  state.dateSequence.forEach((dateKey) => {
+    const card = renderDayCard(dateKey);
+    calendarEl.appendChild(card);
+  });
+  applyFilters();
+}
+
+function renderDayCard(dateKey) {
+  const plan = ensureDay(dateKey);
+  const card = document.createElement('article');
+  card.className = 'day-card';
+  card.dataset.date = dateKey;
+  card.dataset.location = plan.loc;
+  const canEdit = state.editing && !state.share.readOnly;
+  card.draggable = canEdit;
+
+  const stripe = document.createElement('span');
+  stripe.className = 'day-card__stripe';
+  const locMeta = state.locations.find((loc) => loc.id === plan.loc);
+  stripe.style.background = locMeta?.color || '#d1d5db';
+  card.appendChild(stripe);
+
+  const header = document.createElement('div');
+  header.className = 'day-card__header';
+  const dateBox = document.createElement('div');
+  dateBox.className = 'day-card__date';
+  const date = new Date(`${dateKey}T00:00:00`);
+  const number = document.createElement('span');
+  number.className = 'day-card__day-number';
+  number.textContent = String(date.getDate());
+  const textWrap = document.createElement('div');
+  textWrap.className = 'day-card__date-text';
+  const month = document.createElement('span');
+  month.textContent = date.toLocaleDateString(undefined, { month: 'short' });
+  const weekday = document.createElement('span');
+  weekday.textContent = date.toLocaleDateString(undefined, { weekday: 'short' });
+  textWrap.append(month, weekday);
+  dateBox.append(number, textWrap);
+  header.appendChild(dateBox);
+
+  const badges = document.createElement('div');
+  badges.className = 'day-card__badges';
+
+  const themeWrap = document.createElement('span');
+  themeWrap.className = 'theme-editor';
+  const themeChip = document.createElement('span');
+  themeChip.className = 'theme-chip';
+  const themeText = plan.theme || state.themes[plan.loc] || 'Set theme';
+  themeChip.textContent = themeText;
+  themeWrap.appendChild(themeChip);
+  if (canEdit) {
+    const editThemeBtn = document.createElement('button');
+    editThemeBtn.type = 'button';
+    editThemeBtn.className = 'theme-editor__button';
+    editThemeBtn.textContent = '✎';
+    editThemeBtn.title = 'Edit theme';
+    editThemeBtn.addEventListener('click', () => openThemeEditor(dateKey, themeWrap));
+    themeWrap.appendChild(editThemeBtn);
+  }
+  badges.appendChild(themeWrap);
+
+  const stayBtn = document.createElement('button');
+  stayBtn.type = 'button';
+  stayBtn.className = 'theme-chip theme-chip--link';
+  stayBtn.textContent = plan.stay ? getStayLabel(plan.stay) : 'Pick stay';
+  stayBtn.disabled = !canEdit;
+  if (canEdit) {
+    stayBtn.addEventListener('click', () => openSheet(dateKey, 'stay'));
+  }
+  badges.appendChild(stayBtn);
+
+  const mapBtn = document.createElement('button');
+  mapBtn.type = 'button';
+  mapBtn.className = 'theme-chip theme-chip--map';
+  mapBtn.textContent = 'Map';
+  mapBtn.addEventListener('click', () => openMap(dateKey));
+  badges.appendChild(mapBtn);
+
+  header.appendChild(badges);
+  card.appendChild(header);
+
+  const meta = document.createElement('div');
+  meta.className = 'day-card__meta';
+  const travelInfo = state.travelCache.get(dateKey);
+  if (travelInfo && travelInfo.minutes > 0) {
+    const travelPill = document.createElement('span');
+    travelPill.className = 'meta-pill';
+    travelPill.innerHTML = `<strong>Travel</strong> ~${travelInfo.minutes} min`;
+    meta.appendChild(travelPill);
+  }
+  const conflicts = state.availability.get(dateKey) || [];
+  conflicts.forEach((warning) => {
+    const warn = document.createElement('span');
+    warn.className = 'meta-pill meta-pill--warning';
+    warn.textContent = warning;
+    meta.appendChild(warn);
+  });
+  card.appendChild(meta);
+
+  const slotsWrap = document.createElement('div');
+  slotsWrap.className = 'slots';
+  ['morning', 'afternoon', 'evening'].forEach((slotName) => {
+    const slotSection = document.createElement('section');
+    slotSection.className = 'slot';
+    slotSection.dataset.slot = slotName;
+    slotSection.dataset.date = dateKey;
+
+    const slotHeader = document.createElement('div');
+    slotHeader.className = 'slot__header';
+    const slotTitle = document.createElement('span');
+    slotTitle.className = 'slot__title';
+    slotTitle.textContent = slotName.toUpperCase();
+    const addBtn = document.createElement('button');
+    addBtn.type = 'button';
+    addBtn.className = 'btn slot__add';
+    addBtn.textContent = 'Add';
+    addBtn.disabled = !canEdit;
+    if (canEdit) {
+      addBtn.addEventListener('click', () => openSheet(dateKey, 'activity', slotName));
+    }
+    slotHeader.append(slotTitle, addBtn);
+    slotSection.appendChild(slotHeader);
+
+    const items = plan.slots?.[slotName] || [];
+    items.forEach((itemId, index) => {
+      const chip = renderChip(dateKey, slotName, itemId, index, canEdit);
+      slotSection.appendChild(chip);
+    });
+
+    slotSection.addEventListener('dragover', handleSlotDragOver);
+    slotSection.addEventListener('dragleave', handleSlotDragLeave);
+    slotSection.addEventListener('drop', handleSlotDrop);
+
+    slotsWrap.appendChild(slotSection);
+  });
+  card.appendChild(slotsWrap);
+
+  const friendRow = document.createElement('div');
+  friendRow.className = 'day-card__friends';
+  state.people.forEach((person) => {
+    const on = plan.friends.includes(person.id);
+    const friendBtn = document.createElement('button');
+    friendBtn.type = 'button';
+    friendBtn.className = 'friend-chip' + (on ? ' friend-chip--on' : '');
+    friendBtn.dataset.friend = person.id;
+    friendBtn.textContent = on ? person.label : `+ ${person.label}`;
+    friendBtn.disabled = !canEdit;
+    if (on && person.color) {
+      friendBtn.style.background = person.color;
+    }
+    if (canEdit) {
+      friendBtn.addEventListener('click', () => toggleFriend(dateKey, person.id));
+    }
+    friendRow.appendChild(friendBtn);
+  });
+  card.appendChild(friendRow);
+
+  if (canEdit) {
+    card.addEventListener('dragstart', handleCardDragStart);
+    card.addEventListener('dragend', () => {
+      state.cardDragSource = null;
+    });
+    card.addEventListener('dragover', (event) => {
+      event.preventDefault();
+      event.dataTransfer.dropEffect = 'move';
+    });
+    card.addEventListener('drop', handleCardDrop);
+  }
+
+  return card;
+}
+function renderChip(dateKey, slotName, itemId, index, canEdit) {
+  const chip = document.createElement('span');
+  chip.className = 'chiplet';
+  chip.dataset.id = itemId;
+  chip.dataset.date = dateKey;
+  chip.dataset.slot = slotName;
+  chip.dataset.index = String(index);
+  chip.dataset.source = 'slot';
+
+  const activity = getActivityById(itemId) || getGuideById(itemId);
+  chip.appendChild(buildChipContent(activity?.label || itemId));
+
+  const locked = isChipLocked(dateKey, itemId);
+  if (locked) {
+    chip.classList.add('locked');
+  }
+
+  if (canEdit && !locked) {
+    chip.draggable = !COARSE_POINTER;
+    chip.addEventListener('dragstart', handleChipDragStart);
+    chip.addEventListener('dragend', handleChipDragEnd);
+  } else {
+    chip.draggable = false;
+  }
+  if (canEdit && !locked) {
+    chip.addEventListener('pointerdown', handleChipPointerDown);
+  }
+
+  if (canEdit) {
+    const actions = document.createElement('span');
+    actions.className = 'chiplet__actions';
+
+    const lockBtn = document.createElement('button');
+    lockBtn.type = 'button';
+    lockBtn.className = 'chiplet__btn';
+    lockBtn.title = locked ? 'Unlock' : 'Lock';
+    lockBtn.textContent = locked ? '🔒' : '🔓';
+    lockBtn.addEventListener('click', (event) => {
+      event.stopPropagation();
+      toggleLock(dateKey, itemId);
+    });
+    actions.appendChild(lockBtn);
+
+    if (!locked) {
+      const removeBtn = document.createElement('button');
+      removeBtn.type = 'button';
+      removeBtn.className = 'chiplet__btn';
+      removeBtn.title = 'Remove';
+      removeBtn.textContent = '✕';
+      removeBtn.addEventListener('click', (event) => {
+        event.stopPropagation();
+        removeChip(dateKey, slotName, index);
+      });
+      actions.appendChild(removeBtn);
+    }
+
+    chip.appendChild(actions);
+  }
+
+  return chip;
+}
+
+function buildChipContent(label) {
+  const fragment = document.createDocumentFragment();
+  const match = /^([0-2]?\d:[0-5]\d)\s+(.*)$/.exec(label);
+  if (match) {
+    const time = document.createElement('span');
+    time.className = 'chiplet__time';
+    time.textContent = match[1];
+    fragment.appendChild(time);
+    fragment.appendChild(document.createTextNode(` ${match[2]}`));
+  } else {
+    fragment.appendChild(document.createTextNode(label));
+  }
+  return fragment;
+}
+
+function openThemeEditor(dateKey, container) {
+  const day = ensureDay(dateKey);
+  container.innerHTML = '';
+  const input = document.createElement('input');
+  input.type = 'text';
+  input.className = 'theme-editor__input';
+  input.value = day.theme || '';
+  container.appendChild(input);
+  input.focus();
+  const finalize = () => {
+    day.theme = input.value.trim();
+    persistState();
+    updateTravelForDay(dateKey);
+    updateAvailabilityWarnings();
+    updateDayCard(dateKey);
+  };
+  const cancel = () => {
+    updateDayCard(dateKey);
+  };
+  input.addEventListener('keydown', (event) => {
+    if (event.key === 'Enter') {
+      finalize();
+    } else if (event.key === 'Escape') {
+      cancel();
+    }
+  });
+  input.addEventListener('blur', finalize);
+}
+
+function toggleFriend(dateKey, friend) {
+  const day = ensureDay(dateKey);
+  const index = day.friends.indexOf(friend);
+  if (index >= 0) {
+    day.friends.splice(index, 1);
+  } else {
+    day.friends.push(friend);
+  }
+  persistState();
+  updateAvailabilityWarnings();
+  updateDayCard(dateKey);
+}
+
+function addActivity(dateKey, slotName, activityId) {
+  if (state.share.readOnly) return;
+  const day = ensureDay(dateKey);
+  day.slots[slotName] = day.slots[slotName] || [];
+  day.slots[slotName].push(activityId);
+  persistState();
+  updateTravelForDay(dateKey);
+  updateAvailabilityWarnings();
+  updateDayCard(dateKey);
+}
+
+function setStay(dateKey, stayId) {
+  if (state.share.readOnly) return;
+  const day = ensureDay(dateKey);
+  day.stay = stayId;
+  persistState();
+  updateDayCard(dateKey);
+}
+function removeChip(dateKey, slotName, index) {
+  const day = ensureDay(dateKey);
+  const list = day.slots?.[slotName];
+  if (!Array.isArray(list)) return;
+  const itemId = list[index];
+  if (isChipLocked(dateKey, itemId)) return;
+  list.splice(index, 1);
+  persistState();
+  updateTravelForDay(dateKey);
+  updateAvailabilityWarnings();
+  updateDayCard(dateKey);
+}
+
+function toggleLock(dateKey, itemId) {
+  const day = ensureDay(dateKey);
+  day.locks = day.locks || {};
+  if (isChipLocked(dateKey, itemId)) {
+    day.locks[itemId] = 0;
+  } else {
+    day.locks[itemId] = 1;
+  }
+  persistState();
+  updateDayCard(dateKey);
+}
+
+function isChipLocked(dateKey, itemId) {
+  const day = ensureDay(dateKey);
+  const override = day.locks?.[itemId];
+  if (override === 1) return true;
+  if (override === 0) return false;
+  const activity = getActivityById(itemId) || getGuideById(itemId);
+  return Boolean(activity?.locked);
+}
+
+function getActivityById(id) {
+  return state.catalog.activity.find((item) => item.id === id);
+}
+
+function getGuideById(id) {
+  return state.catalog.guide.find((item) => item.id === id);
+}
+
+function getStayById(id) {
+  return state.catalog.stay.find((item) => item.id === id);
+}
+
+function getStayLabel(id) {
+  return getStayById(id)?.label || id;
+}
+
+function getActivityLabel(id) {
+  return (getActivityById(id) || getGuideById(id))?.label || id;
+}
+
+function applyFilters() {
+  const cards = calendarEl.querySelectorAll('.day-card');
+  cards.forEach((card) => {
+    const dateKey = card.dataset.date;
+    const plan = ensureDay(dateKey);
+    const friendMatch = !state.filter.friends.size || plan.friends.some((friend) => state.filter.friends.has(friend));
+    const locationMatch = !state.filter.locations.size || state.filter.locations.has(plan.loc);
+    card.style.display = friendMatch && locationMatch ? '' : 'none';
+  });
+}
+
+function syncFilterButtons() {
+  document.querySelectorAll('.chip[data-friend]').forEach((chip) => {
+    chip.setAttribute('aria-pressed', state.filter.friends.has(chip.dataset.friend) ? 'true' : 'false');
+  });
+  document.querySelectorAll('.chip[data-location]').forEach((chip) => {
+    chip.setAttribute('aria-pressed', state.filter.locations.has(chip.dataset.location) ? 'true' : 'false');
+  });
+  if (allFilterBtn) {
+    const noneActive = !state.filter.friends.size && !state.filter.locations.size;
+    allFilterBtn.setAttribute('aria-pressed', noneActive ? 'true' : 'false');
+  }
+}
+
+function updateFilterFeedback() {
+  const friendText = state.filter.friends.size
+    ? `Friends: ${Array.from(state.filter.friends).join(', ')}`
+    : 'Friends: All';
+  const locationText = state.filter.locations.size
+    ? `Places: ${Array.from(state.filter.locations).join(', ')}`
+    : 'Places: All';
+  const status = state.message ? ` — ${state.message}` : '';
+  filterFeedbackEl.textContent = `${friendText} • ${locationText}${status}`;
+}
+
+function setStatusMessage(text, tone = 'info') {
+  state.message = text;
+  updateFilterFeedback();
+  if (statusTimer) clearTimeout(statusTimer);
+  if (text) {
+    statusTimer = setTimeout(() => {
+      state.message = '';
+      updateFilterFeedback();
+    }, tone === 'error' ? 6000 : 4000);
+  }
+}
+
+function updateActionStates() {
+  if (editBtn) {
+    editBtn.textContent = state.editing ? 'Done' : 'Edit';
+    editBtn.disabled = state.share.readOnly;
+  }
+  if (wizardBtn) {
+    wizardBtn.disabled = state.share.readOnly;
+  }
+  if (saveGithubBtn) {
+    saveGithubBtn.disabled = state.share.readOnly;
+  }
+  if (clearPoolBtn) {
+    clearPoolBtn.disabled = !state.plan.pool.length || state.share.readOnly;
+  }
+  if (readonlyBanner) {
+    readonlyBanner.hidden = !state.share.readOnly;
+  }
+}
+function updateDayCard(dateKey) {
+  const existing = calendarEl.querySelector(`.day-card[data-date="${dateKey}"]`);
+  if (!existing) return;
+  const replacement = renderDayCard(dateKey);
+  calendarEl.replaceChild(replacement, existing);
+  applyFilters();
+}
+
+function updateTravelCache() {
+  state.travelCache = new Map();
+  state.dateSequence.forEach((dateKey) => {
+    state.travelCache.set(dateKey, calculateTravelForDay(dateKey));
+  });
+}
+
+function updateTravelForDay(dateKey) {
+  state.travelCache.set(dateKey, calculateTravelForDay(dateKey));
+}
+
+function calculateTravelForDay(dateKey) {
+  const plan = ensureDay(dateKey);
+  const ordered = [];
+  ['morning', 'afternoon', 'evening'].forEach((slot) => {
+    (plan.slots[slot] || []).forEach((id) => {
+      const item = getActivityById(id) || getGuideById(id);
+      if (!item?.coord) return;
+      const coords = state.coordinates[item.coord];
+      if (!Array.isArray(coords)) return;
+      ordered.push({ coords, label: item.label || id });
+    });
+  });
+  if (ordered.length <= 1) {
+    return { minutes: 0, points: ordered };
+  }
+  let totalMinutes = 0;
+  for (let i = 1; i < ordered.length; i += 1) {
+    const from = ordered[i - 1].coords;
+    const to = ordered[i].coords;
+    const distanceKm = haversineKm(from[0], from[1], to[0], to[1]);
+    const travelMinutes = Math.max(10, Math.round((distanceKm / TRAVEL_SPEED_KMH) * 60));
+    totalMinutes += travelMinutes;
+  }
+  return { minutes: totalMinutes, points: ordered };
+}
+
+function haversineKm(lat1, lon1, lat2, lon2) {
+  const toRad = (value) => (value * Math.PI) / 180;
+  const R = 6371;
+  const dLat = toRad(lat2 - lat1);
+  const dLon = toRad(lon2 - lon1);
+  const a =
+    Math.sin(dLat / 2) * Math.sin(dLat / 2) +
+    Math.cos(toRad(lat1)) * Math.cos(toRad(lat2)) * Math.sin(dLon / 2) * Math.sin(dLon / 2);
+  const c = 2 * Math.atan2(Math.sqrt(a), Math.sqrt(1 - a));
+  return R * c;
+}
+
+function updateAvailabilityWarnings() {
+  const warnings = new Map();
+  const base = state.userConfig.baseLocation;
+  const nanaWork = state.userConfig.constraints.nanaWork;
+  const maxAway = Number(state.userConfig.constraints.maxAway) || 0;
+  let consecutiveAway = 0;
+  state.dateSequence.forEach((dateKey) => {
+    const day = ensureDay(dateKey);
+    let dayWarnings = [];
+    const includesNana = day.friends.includes('Nana');
+    const isAway = includesNana && base && day.loc !== base;
+    if (includesNana) {
+      const weekday = new Date(`${dateKey}T00:00:00`).getDay();
+      if (nanaWork && isAway && (weekday === 2 || weekday === 5)) {
+        dayWarnings.push('Nana away on work day');
+      }
+      if (isAway) {
+        consecutiveAway += 1;
+        if (maxAway && consecutiveAway > maxAway) {
+          dayWarnings.push(`Nana away ${consecutiveAway} days (max ${maxAway})`);
+        }
+      } else {
+        consecutiveAway = 0;
+      }
+    } else {
+      consecutiveAway = 0;
+    }
+    if (dayWarnings.length) {
+      warnings.set(dateKey, dayWarnings);
+    }
+  });
+  state.availability = warnings;
+}
+function openSheet(day, tab = 'activity', slot = 'morning') {
+  if (state.share.readOnly) return;
+  state.sheet = { open: true, day, tab, slot };
+  sheetTitle.textContent = 'Add to day';
+  const prettyDate = formatLongDate(day);
+  sheetSubtitle.textContent = `${prettyDate} — ${slot.toUpperCase()}`;
+  sheetEl.classList.add('sheet--open');
+  sheetBackdrop.removeAttribute('aria-hidden');
+  sheetEl.removeAttribute('aria-hidden');
+  document.body.classList.add('sheet-open');
+  renderSheet();
+}
+
+function closeSheet() {
+  state.sheet.open = false;
+  sheetEl.classList.remove('sheet--open');
+  sheetBackdrop.setAttribute('aria-hidden', 'true');
+  sheetEl.setAttribute('aria-hidden', 'true');
+  document.body.classList.remove('sheet-open');
+}
+
+function renderSheet() {
+  const { day, tab, slot } = state.sheet;
+  sheetBody.innerHTML = '';
+  const dayPlan = ensureDay(day);
+  const activeTab = sheetEl.querySelector(`.tab[data-tab="${tab}"]`);
+  sheetEl.querySelectorAll('.tab').forEach((btn) => {
+    btn.setAttribute('aria-selected', btn === activeTab ? 'true' : 'false');
+  });
+
+  const makeGroup = (title, color) => {
+    const group = document.createElement('div');
+    group.className = 'sheet-group';
+    const header = document.createElement('div');
+    header.className = 'sheet-group__header';
+    const swatch = document.createElement('span');
+    swatch.className = 'sheet-group__swatch';
+    swatch.style.background = color;
+    const label = document.createElement('span');
+    label.textContent = title;
+    header.append(swatch, label);
+    group.appendChild(header);
+    const list = document.createElement('div');
+    list.className = 'sheet-group__list';
+    group.appendChild(list);
+    sheetBody.appendChild(group);
+    return list;
+  };
+
+  if (tab === 'activity') {
+    state.locationOrder.forEach((locId) => {
+      const meta = state.locations.find((loc) => loc.id === locId);
+      const color = meta?.color || '#d1d5db';
+      const list = makeGroup(meta?.label || locId, color);
+      const items = state.catalog.activity.filter((item) => item.city === locId);
+      items.forEach((item) => {
+        const card = buildSheetCard(item.label, {
+          primary: 'Add',
+          onPrimary: () => {
+            addActivity(day, slot, item.id);
+            closeSheet();
+          },
+        });
+        if ((dayPlan.slots[slot] || []).includes(item.id)) {
+          card.classList.add('sheet-card--selected');
+        }
+        list.appendChild(card);
+      });
+      const guides = state.catalog.guide.filter((item) => item.city === locId);
+      guides.forEach((item) => {
+        const card = buildSheetCard(`${item.label}`, {
+          primary: 'Pool',
+          onPrimary: () => {
+            addToPool(item.id);
+            setStatusMessage('Saved to pool.');
+          },
+          meta: 'Guide pick',
+        });
+        list.appendChild(card);
+      });
+    });
+    sheetBody.appendChild(buildCustomActivityForm(day, slot));
+  }
+
+  if (tab === 'stay') {
+    state.locationOrder.forEach((locId) => {
+      const meta = state.locations.find((loc) => loc.id === locId);
+      const color = meta?.color || '#d1d5db';
+      const list = makeGroup(meta?.label || locId, color);
+      const items = state.catalog.stay.filter((item) => item.city === locId);
+      items.forEach((item) => {
+        const card = buildSheetCard(item.label, {
+          primary: 'Set stay',
+          onPrimary: () => {
+            setStay(day, item.id);
+            closeSheet();
+          },
+          meta: item.url ? 'Link available' : '',
+        });
+        if (dayPlan.stay === item.id) {
+          card.classList.add('sheet-card--selected');
+        }
+        list.appendChild(card);
+      });
+    });
+    sheetBody.appendChild(buildCustomStayForm(day));
+  }
+
+  if (tab === 'booking') {
+    state.locationOrder.forEach((locId) => {
+      const meta = state.locations.find((loc) => loc.id === locId);
+      const color = meta?.color || '#d1d5db';
+      const list = makeGroup(meta?.label || locId, color);
+      const items = state.catalog.booking.filter((item) => item.city === locId);
+      items.forEach((item) => {
+        const card = buildSheetCard(item.label, {
+          primary: 'Open',
+          onPrimary: () => window.open(item.url, '_blank', 'noopener'),
+        });
+        list.appendChild(card);
+      });
+    });
+    sheetBody.appendChild(buildCustomBookingForm());
+  }
+}
+
+function buildSheetCard(label, actions = {}) {
+  const card = document.createElement('div');
+  card.className = 'sheet-card';
+  const text = document.createElement('div');
+  text.textContent = label;
+  card.appendChild(text);
+  if (actions.meta) {
+    const meta = document.createElement('span');
+    meta.className = 'sheet-card__meta';
+    meta.textContent = actions.meta;
+    card.appendChild(meta);
+  }
+  if (actions.primary) {
+    const button = document.createElement('button');
+    button.type = 'button';
+    button.className = 'btn';
+    button.textContent = actions.primary;
+    button.addEventListener('click', actions.onPrimary);
+    card.appendChild(button);
+  }
+  return card;
+}
+
+function buildCustomActivityForm(day, slot) {
+  const wrapper = document.createElement('form');
+  wrapper.className = 'sheet__custom';
+  wrapper.innerHTML = `
+    <strong>Add custom activity</strong>
+    <label>Title<input name="title" required /></label>
+    <label>Area<select name="city"></select></label>
+    <label>Coordinates <span class="sheet-card__meta">lat,lng or existing key</span><input name="coord" placeholder="34.68,135.50" /></label>
+    <label>Type<select name="kind"><option value="activity">Activity</option><option value="guide">Guide pick</option></select></label>
+    <div class="sheet__custom-actions">
+      <button type="submit" class="btn">Save</button>
+    </div>
+  `;
+  const select = wrapper.querySelector('select[name="city"]');
+  state.locationOrder.forEach((locId) => {
+    const option = document.createElement('option');
+    option.value = locId;
+    const meta = state.locations.find((loc) => loc.id === locId);
+    option.textContent = meta?.label || locId;
+    select.appendChild(option);
+  });
+  wrapper.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const form = event.currentTarget;
+    const formData = new FormData(form);
+    const title = formData.get('title')?.toString().trim();
+    const city = formData.get('city')?.toString();
+    const coordInput = formData.get('coord')?.toString().trim();
+    const kind = formData.get('kind')?.toString();
+    if (!title || !city) return;
+    const id = `custom-${Date.now()}`;
+    let coordKey = null;
+    if (coordInput) {
+      coordKey = ensureCustomCoordinate(coordInput);
+    }
+    const entry = { id, city, label: title };
+    if (coordKey) entry.coord = coordKey;
+    if (kind === 'guide') {
+      state.customCatalog.guide.push(entry);
+      addToPool(id);
+      setStatusMessage('Guide saved to pool.');
+    } else {
+      state.customCatalog.activity.push(entry);
+      addActivity(day, slot, id);
+    }
+    persistState();
+    rebuildDerivedData();
+    renderSheet();
+  });
+  return wrapper;
+}
+
+function buildCustomStayForm(day) {
+  const wrapper = document.createElement('form');
+  wrapper.className = 'sheet__custom';
+  wrapper.innerHTML = `
+    <strong>Add custom stay</strong>
+    <label>Title<input name="title" required /></label>
+    <label>Area<select name="city"></select></label>
+    <label>Link<input name="url" type="url" placeholder="https://" /></label>
+    <div class="sheet__custom-actions"><button type="submit" class="btn">Save</button></div>
+  `;
+  const select = wrapper.querySelector('select[name="city"]');
+  state.locationOrder.forEach((locId) => {
+    const option = document.createElement('option');
+    option.value = locId;
+    const meta = state.locations.find((loc) => loc.id === locId);
+    option.textContent = meta?.label || locId;
+    select.appendChild(option);
+  });
+  wrapper.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const title = formData.get('title')?.toString().trim();
+    const city = formData.get('city')?.toString();
+    if (!title || !city) return;
+    const entry = {
+      id: `custom-stay-${Date.now()}`,
+      city,
+      label: title,
+      url: formData.get('url')?.toString().trim() || '',
+    };
+    state.customCatalog.stay.push(entry);
+    persistState();
+    rebuildDerivedData();
+    setStay(day, entry.id);
+    renderSheet();
+  });
+  return wrapper;
+}
+
+function buildCustomBookingForm() {
+  const wrapper = document.createElement('form');
+  wrapper.className = 'sheet__custom';
+  wrapper.innerHTML = `
+    <strong>Add booking link</strong>
+    <label>Title<input name="title" required /></label>
+    <label>Area<select name="city"></select></label>
+    <label>Link<input name="url" type="url" placeholder="https://" required /></label>
+    <div class="sheet__custom-actions"><button type="submit" class="btn">Save</button></div>
+  `;
+  const select = wrapper.querySelector('select[name="city"]');
+  state.locationOrder.forEach((locId) => {
+    const option = document.createElement('option');
+    option.value = locId;
+    const meta = state.locations.find((loc) => loc.id === locId);
+    option.textContent = meta?.label || locId;
+    select.appendChild(option);
+  });
+  wrapper.addEventListener('submit', (event) => {
+    event.preventDefault();
+    const formData = new FormData(event.currentTarget);
+    const title = formData.get('title')?.toString().trim();
+    const city = formData.get('city')?.toString();
+    const url = formData.get('url')?.toString().trim();
+    if (!title || !city || !url) return;
+    const entry = { id: `custom-book-${Date.now()}`, city, label: title, url };
+    state.customCatalog.booking.push(entry);
+    persistState();
+    rebuildDerivedData();
+    renderSheet();
+  });
+  return wrapper;
+}
+
+function ensureCustomCoordinate(input) {
+  if (state.coordinates[input]) return input;
+  const [latStr, lonStr] = input.split(',');
+  const lat = Number(latStr?.trim());
+  const lon = Number(lonStr?.trim());
+  if (!Number.isFinite(lat) || !Number.isFinite(lon)) {
+    return input;
+  }
+  const key = `custom-coord-${Date.now()}`;
+  state.customCoordinates[key] = [lat, lon];
+  state.coordinates[key] = [lat, lon];
+  return key;
+}
+function addToPool(id) {
+  if (!state.plan.pool.includes(id)) {
+    state.plan.pool.push(id);
+    persistState();
+    renderPool();
+    updateActionStates();
+  }
+}
+
+function removeFromPool(index) {
+  state.plan.pool.splice(index, 1);
+  persistState();
+  renderPool();
+  updateActionStates();
+}
+
+function clearPool() {
+  state.plan.pool = [];
+  persistState();
+  renderPool();
+  updateActionStates();
+}
+
+function moveChip(dragData, targetDate, targetSlot, targetIndex = null) {
+  if (!dragData || state.share.readOnly) return;
+  const { source, date: sourceDate, slot: sourceSlot, index, id } = dragData;
+  if (!id) return;
+  if (source === 'slot') {
+    const sourceDay = ensureDay(sourceDate);
+    if (isChipLocked(sourceDate, id)) return;
+    const sourceList = sourceDay.slots?.[sourceSlot];
+    if (Array.isArray(sourceList)) {
+      if (sourceList[index] === id) {
+        sourceList.splice(index, 1);
+      } else {
+        const fallback = sourceList.indexOf(id);
+        if (fallback >= 0) sourceList.splice(fallback, 1);
+      }
+    }
+  } else if (source === 'pool') {
+    state.plan.pool.splice(index, 1);
+  }
+
+  const targetDay = ensureDay(targetDate);
+  targetDay.slots[targetSlot] = targetDay.slots[targetSlot] || [];
+  const list = targetDay.slots[targetSlot];
+  if (targetIndex === null || targetIndex >= list.length) {
+    list.push(id);
+  } else {
+    list.splice(targetIndex, 0, id);
+  }
+  persistState();
+  if (sourceDate) {
+    updateTravelForDay(sourceDate);
+  }
+  if (sourceDate !== targetDate) {
+    updateTravelForDay(targetDate);
+  }
+  updateAvailabilityWarnings();
+  if (sourceDate) updateDayCard(sourceDate);
+  if (sourceDate !== targetDate) updateDayCard(targetDate);
+  renderPool();
+  updateActionStates();
+}
+
+function moveChipToPool(dragData) {
+  if (!dragData || state.share.readOnly) return;
+  const { source, date: sourceDate, slot: sourceSlot, index, id } = dragData;
+  if (source === 'slot') {
+    const day = ensureDay(sourceDate);
+    if (isChipLocked(sourceDate, id)) return;
+    const list = day.slots?.[sourceSlot];
+    if (Array.isArray(list)) {
+      if (list[index] === id) {
+        list.splice(index, 1);
+      } else {
+        const fallback = list.indexOf(id);
+        if (fallback >= 0) list.splice(fallback, 1);
+      }
+    }
+    persistState();
+    if (sourceDate) {
+      updateTravelForDay(sourceDate);
+      updateDayCard(sourceDate);
+    }
+    updateAvailabilityWarnings();
+  }
+  addToPool(id);
+}
+
+function handleSlotDragOver(event) {
+  if (!state.editing || state.share.readOnly) return;
+  event.preventDefault();
+  event.currentTarget.dataset.dropHover = 'true';
+  event.dataTransfer.dropEffect = 'move';
+}
+
+function handleSlotDragLeave(event) {
+  event.currentTarget.removeAttribute('data-drop-hover');
+}
+
+function handleSlotDrop(event) {
+  if (!state.editing || state.share.readOnly) return;
+  event.preventDefault();
+  event.currentTarget.removeAttribute('data-drop-hover');
+  if (!state.chipDragData) return;
+  const targetDate = event.currentTarget.dataset.date;
+  const targetSlot = event.currentTarget.dataset.slot;
+  const index = computeDropIndex(event.currentTarget, event.clientX);
+  moveChip(state.chipDragData, targetDate, targetSlot, index);
+  state.chipDragData = null;
+}
+
+function computeDropIndex(slotEl, clientX) {
+  const chips = Array.from(slotEl.querySelectorAll('.chiplet'));
+  let index = chips.length;
+  chips.forEach((chip, i) => {
+    const rect = chip.getBoundingClientRect();
+    if (clientX < rect.left + rect.width / 2 && index === chips.length) {
+      index = i;
+    }
+  });
+  return index;
+}
+
+function handleChipDragStart(event) {
+  const chip = event.currentTarget;
+  state.chipDragData = buildDragDataFromElement(chip);
+  event.dataTransfer.effectAllowed = 'move';
+  event.dataTransfer.setData('text/plain', JSON.stringify({ type: 'chip', id: chip.dataset.id }));
+  chip.classList.add('chiplet--dragging');
+}
+
+function handleChipDragEnd(event) {
+  if (event.currentTarget) {
+    event.currentTarget.classList.remove('chiplet--dragging');
+  }
+  state.chipDragData = null;
+  document.querySelectorAll('.slot[data-drop-hover]').forEach((slot) => slot.removeAttribute('data-drop-hover'));
+}
+
+function buildDragDataFromElement(chip) {
+  const source = chip.dataset.source || 'slot';
+  if (source === 'pool') {
+    return {
+      source: 'pool',
+      index: Number(chip.dataset.index),
+      id: chip.dataset.id,
+    };
+  }
+  return {
+    source: 'slot',
+    date: chip.dataset.date,
+    slot: chip.dataset.slot,
+    index: Number(chip.dataset.index),
+    id: chip.dataset.id,
+  };
+}
+
+function handleCardDragStart(event) {
+  if (!state.editing || state.share.readOnly) {
+    event.preventDefault();
+    return;
+  }
+  state.cardDragSource = event.currentTarget.dataset.date;
+  event.dataTransfer.effectAllowed = 'move';
+  event.dataTransfer.setData('text/plain', 'day-card');
+}
+
+function handleCardDrop(event) {
+  if (!state.editing || state.share.readOnly) return;
+  event.preventDefault();
+  const targetDate = event.currentTarget.dataset.date;
+  if (!state.cardDragSource || !targetDate || state.cardDragSource === targetDate) return;
+  const sourcePlan = state.plan.days[state.cardDragSource];
+  state.plan.days[state.cardDragSource] = state.plan.days[targetDate];
+  state.plan.days[targetDate] = sourcePlan;
+  persistState();
+  updateTravelForDay(state.cardDragSource);
+  updateTravelForDay(targetDate);
+  updateAvailabilityWarnings();
+  renderCalendar();
+  state.cardDragSource = null;
+}
+function handleChipPointerDown(event) {
+  if (!state.editing || state.share.readOnly) return;
+  if (event.pointerType === 'mouse') return;
+  const chip = event.currentTarget;
+  if (chip.classList.contains('locked')) return;
+  event.preventDefault();
+  chip.setPointerCapture(event.pointerId);
+  state.pointerDrag = {
+    pointerId: event.pointerId,
+    chip,
+    startX: event.clientX,
+    startY: event.clientY,
+    active: false,
+    placeholder: null,
+    ghost: null,
+    target: null,
+    source: buildDragDataFromElement(chip),
+    timer: setTimeout(() => startPointerDrag(event), 180),
+  };
+  chip.addEventListener('pointermove', handleChipPointerMove);
+  chip.addEventListener('pointerup', handleChipPointerUp);
+  chip.addEventListener('pointercancel', handleChipPointerCancel);
+}
+
+function startPointerDrag(event) {
+  const drag = state.pointerDrag;
+  if (!drag) return;
+  drag.active = true;
+  drag.chip.classList.add('chiplet--dragging');
+  drag.chip.style.visibility = 'hidden';
+  const placeholder = document.createElement('span');
+  placeholder.className = 'chiplet-placeholder';
+  drag.placeholder = placeholder;
+  drag.chip.parentElement.insertBefore(placeholder, drag.chip);
+  const ghost = drag.chip.cloneNode(true);
+  ghost.classList.add('chiplet-ghost');
+  document.body.appendChild(ghost);
+  drag.ghost = ghost;
+  updatePointerGhostPosition(event.clientX, event.clientY);
+}
+
+function handleChipPointerMove(event) {
+  const drag = state.pointerDrag;
+  if (!drag) return;
+  if (!drag.active) {
+    const dx = Math.abs(event.clientX - drag.startX);
+    const dy = Math.abs(event.clientY - drag.startY);
+    if (dx > 6 || dy > 6) {
+      clearTimeout(drag.timer);
+      startPointerDrag(event);
+    }
+  }
+  if (!drag.active) return;
+  updatePointerGhostPosition(event.clientX, event.clientY);
+  updatePointerDropTarget(event.clientX, event.clientY);
+}
+
+function handleChipPointerUp() {
+  finalizePointerDrag();
+}
+
+function handleChipPointerCancel() {
+  finalizePointerDrag(true);
+}
+
+function finalizePointerDrag(cancelled = false) {
+  const drag = state.pointerDrag;
+  if (!drag) return;
+  clearTimeout(drag.timer);
+  drag.chip.releasePointerCapture(drag.pointerId);
+  drag.chip.removeEventListener('pointermove', handleChipPointerMove);
+  drag.chip.removeEventListener('pointerup', handleChipPointerUp);
+  drag.chip.removeEventListener('pointercancel', handleChipPointerCancel);
+  drag.chip.style.visibility = '';
+  drag.chip.classList.remove('chiplet--dragging');
+  if (drag.placeholder) drag.placeholder.remove();
+  if (drag.ghost) drag.ghost.remove();
+  if (!cancelled && drag.active && drag.target) {
+    if (drag.target.type === 'slot') {
+      moveChip(
+        drag.source,
+        drag.target.date,
+        drag.target.slot,
+        drag.target.index,
+      );
+    } else if (drag.target.type === 'pool') {
+      moveChipToPool(drag.source);
+    }
+  }
+  state.pointerDrag = null;
+}
+
+function updatePointerGhostPosition(x, y) {
+  const drag = state.pointerDrag;
+  if (!drag?.ghost) return;
+  drag.ghost.style.left = `${x}px`;
+  drag.ghost.style.top = `${y}px`;
+}
+
+function updatePointerDropTarget(x, y) {
+  const element = document.elementFromPoint(x, y);
+  let target = null;
+  const slot = element?.closest('.slot');
+  if (slot) {
+    const date = slot.dataset.date;
+    const slotName = slot.dataset.slot;
+    const index = computeDropIndex(slot, x);
+    target = { type: 'slot', date, slot: slotName, index, element: slot };
+  } else if (element?.closest('#pool')) {
+    target = { type: 'pool' };
+  }
+  positionPlaceholder(target);
+  state.pointerDrag.target = target;
+}
+
+function positionPlaceholder(target) {
+  const drag = state.pointerDrag;
+  if (!drag || !drag.placeholder) return;
+  if (!target) {
+    drag.placeholder.remove();
+    return;
+  }
+  if (target.type === 'slot') {
+    const slotEl = target.element;
+    const chips = Array.from(slotEl.querySelectorAll('.chiplet'));
+    if (target.index >= chips.length) {
+      slotEl.appendChild(drag.placeholder);
+    } else {
+      slotEl.insertBefore(drag.placeholder, chips[target.index]);
+    }
+  } else if (target.type === 'pool') {
+    poolChipsEl.appendChild(drag.placeholder);
+  }
+}
+function openMap(dateKey) {
+  const plan = ensureDay(dateKey);
+  mapOverlay.classList.add('is-open');
+  mapOverlay.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('map-open');
+  const title = document.getElementById('mapTitle');
+  title.textContent = `${formatLongDate(dateKey)} — ${plan.theme || state.themes[plan.loc] || ''}`;
+  const travelInfo = state.travelCache.get(dateKey) || calculateTravelForDay(dateKey);
+  setTimeout(() => {
+    if (!state.map.instance) {
+      const map = window.L.map('map');
+      window.L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+        maxZoom: 19,
+        attribution: '© OpenStreetMap contributors',
+      }).addTo(map);
+      state.map.instance = map;
+      state.map.markers = window.L.layerGroup().addTo(map);
+    }
+    const map = state.map.instance;
+    map.invalidateSize();
+    state.map.markers.clearLayers();
+    if (state.map.route) {
+      map.removeLayer(state.map.route);
+      state.map.route = null;
+    }
+    const points = travelInfo.points || [];
+    if (!points.length) {
+      map.setView([35.0, 135.5], 5);
+      return;
+    }
+    const latlngs = [];
+    points.forEach((point, index) => {
+      const icon = window.L.divIcon({ className: 'map-marker', html: `<span>${index + 1}</span>` });
+      const marker = window.L.marker(point.coords, { icon }).addTo(state.map.markers);
+      marker.bindPopup(point.label);
+      latlngs.push(point.coords);
+    });
+    state.map.route = window.L.polyline(latlngs, { color: '#2d3a64', weight: 3, opacity: 0.8 }).addTo(map);
+    map.fitBounds(state.map.route.getBounds().pad(0.2));
+  }, 60);
+}
+
+function closeMap() {
+  mapOverlay.classList.remove('is-open');
+  mapOverlay.setAttribute('aria-hidden', 'true');
+  document.body.classList.remove('map-open');
+}
+function formatLongDate(dateKey) {
+  const date = new Date(`${dateKey}T00:00:00`);
+  const weekday = date.toLocaleDateString(undefined, { weekday: 'long' });
+  const month = date.toLocaleDateString(undefined, { month: 'short' });
+  return `${weekday}, ${month} ${date.getDate()}`;
+}
+
+function formatSummaryDate(dateKey) {
+  const date = new Date(`${dateKey}T00:00:00`);
+  return `${date.toLocaleDateString(undefined, { month: 'short' })} ${date.getDate()}`;
+}
+function exportIcs() {
+  const now = new Date();
+  const dtstamp = formatIcsDateTimeUtc(now);
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'CALSCALE:GREGORIAN',
+    'PRODID:-//Canvas6 Trip Planner//EN',
+    'BEGIN:VTIMEZONE',
+    'TZID:Asia/Tokyo',
+    'X-LIC-LOCATION:Asia/Tokyo',
+    'BEGIN:STANDARD',
+    'TZOFFSETFROM:+0900',
+    'TZOFFSETTO:+0900',
+    'TZNAME:JST',
+    'DTSTART:19700101T000000',
+    'END:STANDARD',
+    'END:VTIMEZONE',
+  ];
+  state.dateSequence.forEach((dateKey) => {
+    const day = ensureDay(dateKey);
+    const dateValue = dateKey.replace(/-/g, '');
+    const title = day.theme || state.themes[day.loc] || 'Trip day';
+    const slotDescriptions = ['morning', 'afternoon', 'evening']
+      .map((slot) => (day.slots[slot] || []).map(getActivityLabel).filter(Boolean).join(' • '))
+      .filter(Boolean)
+      .join(' / ');
+    const descriptionParts = [];
+    if (slotDescriptions) descriptionParts.push(slotDescriptions);
+    if (day.stay) descriptionParts.push(`Stay: ${getStayLabel(day.stay)}`);
+    if (day.friends.length) descriptionParts.push(`Friends: ${day.friends.join(', ')}`);
+    lines.push('BEGIN:VEVENT');
+    lines.push(`UID:${dateValue}@jp-canvas6`);
+    lines.push(`DTSTAMP:${dtstamp}`);
+    lines.push(`SUMMARY:${escapeIcsText(`${formatSummaryDate(dateKey)} — ${title}`)}`);
+    lines.push(`DTSTART;TZID=Asia/Tokyo:${dateValue}T090000`);
+    lines.push(`DTEND;TZID=Asia/Tokyo:${dateValue}T210000`);
+    lines.push(`DESCRIPTION:${escapeIcsText(descriptionParts.join(' / '))}`);
+    lines.push(`LOCATION:${escapeIcsText(day.loc)}`);
+    lines.push('END:VEVENT');
+  });
+  lines.push('END:VCALENDAR');
+  const blob = new Blob([lines.join('\n')], { type: 'text/calendar;charset=utf-8' });
+  const link = document.createElement('a');
+  link.href = URL.createObjectURL(blob);
+  link.download = `${state.userConfig.title.replace(/\s+/g, '-')}.ics`;
+  link.click();
+  URL.revokeObjectURL(link.href);
+}
+
+function escapeIcsText(value) {
+  return String(value || '').replace(/[\\;,\n]/g, (match) => {
+    if (match === '\\') return '\\\\';
+    if (match === ';') return '\\;';
+    if (match === ',') return '\\,';
+    return '\\n';
+  });
+}
+
+function formatIcsDateTimeUtc(date) {
+  const pad = (num) => String(num).padStart(2, '0');
+  return `${date.getUTCFullYear()}${pad(date.getUTCMonth() + 1)}${pad(date.getUTCDate())}T${pad(date.getUTCHours())}${pad(date.getUTCMinutes())}${pad(date.getUTCSeconds())}Z`;
+}
+function generateShareLink() {
+  const payload = {
+    version: state.definition.version,
+    plan: state.plan,
+    customCatalog: state.customCatalog,
+    customCoordinates: state.customCoordinates,
+    userConfig: state.userConfig,
+  };
+  const encoded = encodeBase64(JSON.stringify(payload));
+  const hash = `${SHARE_PREFIX}${encoded}`;
+  window.location.hash = hash;
+  if (navigator.clipboard) {
+    navigator.clipboard.writeText(window.location.href).then(() => {
+      setStatusMessage('Share link copied.');
+    });
+  } else {
+    setStatusMessage('Share link ready.');
+  }
+}
+
+function loadFromHash() {
+  if (!window.location.hash.startsWith(SHARE_PREFIX)) return false;
+  try {
+    const encoded = window.location.hash.slice(SHARE_PREFIX.length);
+    const json = decodeBase64(encoded);
+    const payload = JSON.parse(json);
+    if (payload.plan) {
+      state.plan = { days: { ...(payload.plan.days || {}) }, pool: Array.isArray(payload.plan.pool) ? payload.plan.pool : [] };
+    }
+    if (payload.customCatalog) {
+      state.customCatalog = payload.customCatalog;
+    }
+    if (payload.customCoordinates) {
+      state.customCoordinates = payload.customCoordinates;
+    }
+    if (payload.userConfig) {
+      state.userConfig = { ...state.userConfig, ...payload.userConfig };
+    }
+    syncPeople();
+    buildDateSequenceForRange();
+    ensurePlanForRange();
+    rebuildDerivedData();
+    state.share.readOnly = true;
+    state.editing = false;
+    return true;
+  } catch (error) {
+    console.warn('Failed to parse shared link', error);
+    return false;
+  }
+}
+
+function decodeBase64(input) {
+  const binary = atob(input);
+  const bytes = new Uint8Array(binary.length);
+  for (let i = 0; i < binary.length; i += 1) {
+    bytes[i] = binary.charCodeAt(i);
+  }
+  return new TextDecoder().decode(bytes);
+}
+function attachGlobalEvents() {
+  if (editBtn) {
+    editBtn.addEventListener('click', () => {
+      if (state.share.readOnly) return;
+      state.editing = !state.editing;
+      renderApp();
+    });
+  }
+  if (shareBtn) {
+    shareBtn.addEventListener('click', generateShareLink);
+  }
+  if (wizardBtn) {
+    wizardBtn.addEventListener('click', openWizard);
+  }
+  if (saveGithubBtn) {
+    saveGithubBtn.addEventListener('click', openGithubDialog);
+  }
+  if (icsBtn) {
+    icsBtn.addEventListener('click', exportIcs);
+  }
+  if (sheetBackdrop) {
+    sheetBackdrop.addEventListener('click', closeSheet);
+  }
+  sheetEl.querySelectorAll('.tab').forEach((tabBtn) => {
+    tabBtn.addEventListener('click', () => {
+      state.sheet.tab = tabBtn.dataset.tab;
+      renderSheet();
+    });
+  });
+  if (clearPoolBtn) {
+    clearPoolBtn.addEventListener('click', clearPool);
+  }
+  if (allFilterBtn) {
+    allFilterBtn.addEventListener('click', clearFilters);
+  }
+  closeMapBtn.addEventListener('click', closeMap);
+  closeWizardBtn.addEventListener('click', closeWizard);
+  closeGithubBtn.addEventListener('click', closeGithubDialog);
+  wizardForm.addEventListener('submit', handleWizardSubmit);
+  githubForm.addEventListener('submit', handleGithubSubmit);
+
+  document.addEventListener('keydown', (event) => {
+    if (event.key === 'Escape') {
+      if (state.sheet.open) closeSheet();
+      if (mapOverlay.classList.contains('is-open')) closeMap();
+      if (!wizardOverlay.getAttribute('aria-hidden')) closeWizard();
+      if (!githubOverlay.getAttribute('aria-hidden')) closeGithubDialog();
+    }
+  });
+}
+function openWizard() {
+  wizardOverlay.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('sheet-open');
+  const titleInput = document.getElementById('wizardTitleInput');
+  const startInput = document.getElementById('wizardStart');
+  const endInput = document.getElementById('wizardEnd');
+  const baseSelect = document.getElementById('wizardBase');
+  const peopleInput = document.getElementById('wizardPeople');
+  const nanaWorkCheck = document.getElementById('wizardNanaWork');
+  const maxAwayInput = document.getElementById('wizardMaxAway');
+  titleInput.value = state.userConfig.title;
+  startInput.value = state.userConfig.range.start;
+  endInput.value = state.userConfig.range.end;
+  baseSelect.innerHTML = '';
+  state.locationOrder.forEach((locId) => {
+    const option = document.createElement('option');
+    option.value = locId;
+    const meta = state.locations.find((loc) => loc.id === locId);
+    option.textContent = meta?.label || locId;
+    if (locId === state.userConfig.baseLocation) option.selected = true;
+    baseSelect.appendChild(option);
+  });
+  peopleInput.value = state.people.map((person) => person.id).join(', ');
+  nanaWorkCheck.checked = Boolean(state.userConfig.constraints.nanaWork);
+  maxAwayInput.value = state.userConfig.constraints.maxAway ?? 3;
+}
+
+function closeWizard() {
+  wizardOverlay.setAttribute('aria-hidden', 'true');
+  document.body.classList.remove('sheet-open');
+}
+
+function handleWizardSubmit(event) {
+  event.preventDefault();
+  const formData = new FormData(wizardForm);
+  const title = formData.get('title')?.toString().trim();
+  const start = formData.get('start')?.toString();
+  const end = formData.get('end')?.toString();
+  const base = formData.get('base')?.toString();
+  const peopleRaw = formData.get('people')?.toString() || '';
+  const nanaWork = Boolean(formData.get('nanaWork'));
+  const maxAway = Number(formData.get('maxAway')) || 3;
+  if (title) state.userConfig.title = title;
+  if (start && end) {
+    state.userConfig.range = { start, end };
+  }
+  if (base) state.userConfig.baseLocation = base;
+  const names = peopleRaw
+    .split(',')
+    .map((name) => name.trim())
+    .filter(Boolean);
+  if (names.length) {
+    state.userConfig.people = names.map((name) => {
+      const existing = state.people.find((person) => person.id === name);
+      return existing ? { id: existing.id, label: existing.label, color: existing.color } : { id: name, label: name };
+    });
+  }
+  state.userConfig.constraints = { nanaWork, maxAway };
+  syncPeople();
+  buildDateSequenceForRange();
+  ensurePlanForRange();
+  rebuildDerivedData();
+  persistState();
+  renderApp();
+  closeWizard();
+  setStatusMessage('Trip setup updated.');
+}
+
+function openGithubDialog() {
+  if (state.share.readOnly) return;
+  githubOverlay.setAttribute('aria-hidden', 'false');
+  document.body.classList.add('sheet-open');
+}
+
+function closeGithubDialog() {
+  githubOverlay.setAttribute('aria-hidden', 'true');
+  document.body.classList.remove('sheet-open');
+}
+
+async function handleGithubSubmit(event) {
+  event.preventDefault();
+  const formData = new FormData(githubForm);
+  const owner = formData.get('owner')?.toString().trim();
+  const repo = formData.get('repo')?.toString().trim();
+  const branch = formData.get('branch')?.toString().trim() || 'main';
+  const path = formData.get('path')?.toString().trim() || 'data/trip.json';
+  const token = formData.get('token')?.toString().trim();
+  const message = formData.get('message')?.toString().trim() || 'Update trip definition';
+  if (!owner || !repo || !token) return;
+  const exportData = assembleTripDefinitionForSave();
+  try {
+    await saveTripDefinitionToGitHub({ token, owner, repo, branch, path, message, content: JSON.stringify(exportData, null, 2) });
+    setStatusMessage('Saved to GitHub.');
+    closeGithubDialog();
+  } catch (error) {
+    console.error('GitHub save failed', error);
+    setStatusMessage('GitHub save failed.', 'error');
+  }
+}
+
+function assembleTripDefinitionForSave() {
+  const defaults = {};
+  Object.entries(state.plan.days).forEach(([dateKey, day]) => {
+    defaults[dateKey] = cloneDay(day);
+  });
+  return {
+    version: state.definition.version,
+    storage: state.definition.storage,
+    trip: {
+      title: state.userConfig.title,
+      range: state.userConfig.range,
+      baseLocation: state.userConfig.baseLocation,
+    },
+    people: state.people.map((person) => ({ id: person.id, label: person.label, color: person.color })),
+    locations: state.locations,
+    themes: state.themes,
+    coordinates: { ...(state.definition.coordinates || {}), ...state.customCoordinates },
+    catalog: {
+      activity: mergeCatalogArrays(state.definition.catalog?.activity, state.customCatalog.activity),
+      guide: mergeCatalogArrays(state.definition.catalog?.guide, state.customCatalog.guide),
+      stay: mergeCatalogArrays(state.definition.catalog?.stay, state.customCatalog.stay),
+      booking: mergeCatalogArrays(state.definition.catalog?.booking, state.customCatalog.booking),
+    },
+    defaults,
+    custom: {
+      constraints: state.userConfig.constraints,
+    },
+    constraints: state.userConfig.constraints,
+  };
+}

--- a/scripts/data.js
+++ b/scripts/data.js
@@ -1,0 +1,113 @@
+const TRIP_SOURCE = new URL('../data/trip.json', import.meta.url);
+
+export async function fetchTripDefinition() {
+  const response = await fetch(TRIP_SOURCE, { cache: 'no-store' });
+  if (!response.ok) {
+    throw new Error(`Unable to load trip definition: ${response.status}`);
+  }
+  const data = await response.json();
+  return normaliseTripDefinition(data);
+}
+
+export function buildStorageKey(definition) {
+  const base = definition?.storage?.baseKey || 'jp-canvas6';
+  const schema = definition?.storage?.schema || definition?.version || 1;
+  return `${base}-v${schema}`;
+}
+
+export function encodeBase64(input) {
+  const encoder = new TextEncoder();
+  const bytes = encoder.encode(input);
+  let binary = '';
+  const chunkSize = 0x8000;
+  for (let i = 0; i < bytes.length; i += chunkSize) {
+    const chunk = bytes.subarray(i, i + chunkSize);
+    binary += String.fromCharCode(...chunk);
+  }
+  return btoa(binary);
+}
+
+export async function saveTripDefinitionToGitHub({
+  token,
+  owner,
+  repo,
+  branch = 'main',
+  path = 'data/trip.json',
+  message = 'Update trip definition',
+  content,
+}) {
+  if (!token || !owner || !repo) {
+    throw new Error('Missing GitHub credentials.');
+  }
+  const headers = {
+    Accept: 'application/vnd.github+json',
+    Authorization: `Bearer ${token}`,
+    'Content-Type': 'application/json',
+  };
+  const apiBase = `https://api.github.com/repos/${owner}/${repo}/contents/${path}`;
+  let sha;
+  const getUrl = new URL(apiBase);
+  if (branch) {
+    getUrl.searchParams.set('ref', branch);
+  }
+  const existing = await fetch(getUrl, { headers });
+  if (existing.status === 200) {
+    const json = await existing.json();
+    sha = json.sha;
+  } else if (existing.status !== 404) {
+    const errText = await existing.text();
+    throw new Error(`Unable to read ${path}: ${errText}`);
+  }
+
+  const body = {
+    message,
+    content: encodeBase64(content),
+    branch,
+  };
+  if (sha) body.sha = sha;
+
+  const putResponse = await fetch(apiBase, {
+    method: 'PUT',
+    headers,
+    body: JSON.stringify(body),
+  });
+
+  if (!putResponse.ok) {
+    const errText = await putResponse.text();
+    throw new Error(`GitHub update failed: ${errText}`);
+  }
+
+  return putResponse.json();
+}
+
+function normaliseTripDefinition(definition = {}) {
+  const result = { ...definition };
+  result.people = Array.isArray(definition.people) ? definition.people.map((person) => ({ ...person })) : [];
+  result.locations = Array.isArray(definition.locations)
+    ? definition.locations.map((loc) => ({ ...loc }))
+    : [];
+  result.catalog = {
+    activity: Array.isArray(definition.catalog?.activity) ? definition.catalog.activity.map((item) => ({ ...item })) : [],
+    stay: Array.isArray(definition.catalog?.stay) ? definition.catalog.stay.map((item) => ({ ...item })) : [],
+    booking: Array.isArray(definition.catalog?.booking) ? definition.catalog.booking.map((item) => ({ ...item })) : [],
+    guide: Array.isArray(definition.catalog?.guide) ? definition.catalog.guide.map((item) => ({ ...item })) : [],
+  };
+  result.coordinates = { ...(definition.coordinates || {}) };
+  result.themes = { ...(definition.themes || {}) };
+  result.defaults = { ...(definition.defaults || {}) };
+  result.trip = {
+    title: definition.trip?.title || 'Trip plan',
+    range: {
+      start: definition.trip?.range?.start || new Date().toISOString().slice(0, 10),
+      end: definition.trip?.range?.end || new Date().toISOString().slice(0, 10),
+    },
+    baseLocation: definition.trip?.baseLocation || result.locations?.[0]?.id || null,
+  };
+  result.storage = {
+    baseKey: definition.storage?.baseKey || 'jp-canvas6',
+    schema: definition.storage?.schema || definition.version || 1,
+  };
+  result.version = definition.version || result.storage.schema || 1;
+  result.constraints = definition.constraints ? { ...definition.constraints } : {};
+  return result;
+}

--- a/styles.css
+++ b/styles.css
@@ -1,0 +1,1018 @@
+:root {
+  --paper: #fcfaf7;
+  --ink: #111827;
+  --muted: #6b7280;
+  --line: #e7e2d8;
+  --shadow: 0 16px 40px rgba(15, 23, 42, 0.08);
+  --radius-card: 18px;
+  --osaka: #2d3a64;
+  --kyoto: #c84e4e;
+  --tokyo: #eecad0;
+  --kobe: #7fafae;
+  --work: #9a948c;
+  --friend-nana: #f7e6ec;
+  --friend-nicole: #ffe4f0;
+  --friend-ken: #eaf7ea;
+  --friend-james: #e6effa;
+  --friend-phil: #e5f4f1;
+  --slot-bg: #f8f3eb;
+  --tab-bg: rgba(255, 255, 255, 0.9);
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, "Noto Sans JP", sans-serif;
+  background: var(--paper);
+  color: var(--ink);
+  -webkit-font-smoothing: antialiased;
+}
+
+body.sheet-open,
+body.map-open {
+  overflow: hidden;
+}
+
+button {
+  font: inherit;
+  color: inherit;
+  background: none;
+  border: none;
+  padding: 0;
+  cursor: pointer;
+}
+
+button:disabled {
+  cursor: not-allowed;
+}
+
+.site-header {
+  position: sticky;
+  top: 0;
+  z-index: 30;
+  backdrop-filter: saturate(1.1) blur(12px);
+  background: rgba(252, 250, 247, 0.95);
+  border-bottom: 1px solid var(--line);
+}
+
+.header-inner {
+  margin: 0 auto;
+  padding: 16px clamp(16px, 4vw, 24px);
+  max-width: 1200px;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.site-title {
+  margin: 0;
+  font-size: clamp(1.5rem, 5vw, 2.4rem);
+  font-weight: 750;
+}
+
+.toolbar {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px 12px;
+  align-items: center;
+}
+
+.toolbar-group {
+  display: inline-flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+}
+
+.toolbar-group--actions {
+  margin-left: auto;
+  gap: 8px;
+}
+
+.toolbar-label {
+  font-size: 0.75rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.02em;
+}
+
+.chip,
+.btn,
+.tab {
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 7px 12px;
+  font-size: 0.82rem;
+  background: #fff;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.chip:hover,
+.btn:hover,
+.tab:hover {
+  transform: translateY(-1px);
+}
+
+.chip[aria-pressed="true"],
+.tab[aria-selected="true"] {
+  box-shadow: 0 0 0 2px rgba(17, 24, 39, 0.08);
+}
+
+.chip[data-friend="Nana"] {
+  background: var(--friend-nana);
+}
+
+.chip[data-friend="Nicole"] {
+  background: var(--friend-nicole);
+}
+
+.chip[data-friend="Ken"] {
+  background: var(--friend-ken);
+}
+
+.chip[data-friend="James"] {
+  background: var(--friend-james);
+}
+
+.chip[data-friend="Phil"] {
+  background: var(--friend-phil);
+}
+
+.chip[data-location="osaka"] {
+  background: rgba(45, 58, 100, 0.12);
+}
+
+.chip[data-location="kyoto"] {
+  background: rgba(200, 78, 78, 0.12);
+}
+
+.chip[data-location="tokyo"] {
+  background: rgba(238, 202, 208, 0.6);
+}
+
+.chip[data-location="kobe"] {
+  background: rgba(127, 175, 174, 0.22);
+}
+
+.chip[data-location="work"] {
+  background: rgba(154, 148, 140, 0.22);
+}
+
+.btn {
+  background: #fff;
+  border-radius: 12px;
+}
+
+.btn--subtle {
+  background: rgba(255, 255, 255, 0.85);
+}
+
+.btn:focus-visible,
+.chip:focus-visible,
+.tab:focus-visible {
+  outline: 2px solid rgba(45, 58, 100, 0.4);
+  outline-offset: 2px;
+}
+
+.legend {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px 16px;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.filter-feedback {
+  min-height: 1.2rem;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.legend-item {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  white-space: nowrap;
+}
+
+.legend-swatch {
+  width: 12px;
+  height: 12px;
+  border-radius: 3px;
+  background: var(--line);
+  display: inline-block;
+}
+
+.legend-swatch[data-swatch="osaka"] {
+  background: var(--osaka);
+}
+
+.legend-swatch[data-swatch="kyoto"] {
+  background: var(--kyoto);
+}
+
+.legend-swatch[data-swatch="tokyo"] {
+  background: var(--tokyo);
+}
+
+.legend-swatch[data-swatch="kobe"] {
+  background: var(--kobe);
+}
+
+.legend-swatch[data-swatch="work"] {
+  background: var(--work);
+}
+
+.main {
+  padding: 24px clamp(16px, 4vw, 24px);
+  max-width: 1200px;
+  margin: 0 auto 80px;
+}
+
+.calendar {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+.banner {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 10px 14px;
+  margin-bottom: 16px;
+  border-radius: 14px;
+  border: 1px solid var(--line);
+  background: rgba(45, 58, 100, 0.08);
+  color: var(--osaka);
+  font-size: 0.85rem;
+}
+
+.banner[hidden] {
+  display: none !important;
+}
+
+.idea-pool {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  margin-bottom: 20px;
+  border: 1px solid var(--line);
+  border-radius: var(--radius-card);
+  background: #fff;
+  box-shadow: var(--shadow);
+}
+
+.idea-pool[hidden] {
+  display: none !important;
+}
+
+.idea-pool__header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: baseline;
+  gap: 12px;
+}
+
+.idea-pool__header h2 {
+  margin: 0;
+  font-size: 1rem;
+}
+
+.idea-pool__hint {
+  margin: 0;
+  font-size: 0.8rem;
+  color: var(--muted);
+}
+
+.idea-pool__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.idea-pool .chiplet {
+  cursor: grab;
+}
+
+.idea-pool .chiplet__actions {
+  margin-left: 0;
+}
+
+@media (min-width: 720px) {
+  .calendar {
+    grid-template-columns: repeat(2, minmax(340px, 1fr));
+  }
+}
+
+@media (min-width: 1120px) {
+  .calendar {
+    grid-template-columns: repeat(3, minmax(360px, 1fr));
+  }
+}
+
+.day-card {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 18px 18px 20px 20px;
+  border-radius: var(--radius-card);
+  border: 1px solid var(--line);
+  background: #fff;
+  box-shadow: var(--shadow);
+  min-height: 180px;
+  transition: transform 0.2s ease;
+}
+
+.day-card[draggable="true"] {
+  cursor: grab;
+}
+
+.day-card__stripe {
+  position: absolute;
+  top: -1px;
+  bottom: -1px;
+  left: -1px;
+  width: 8px;
+  border-radius: var(--radius-card) 0 0 var(--radius-card);
+}
+
+.day-card__header {
+  display: flex;
+  gap: 12px;
+  justify-content: space-between;
+  align-items: flex-start;
+  flex-wrap: wrap;
+}
+
+.day-card__date {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+}
+
+.day-card__day-number {
+  font-size: clamp(1.8rem, 7vw, 2.5rem);
+  font-weight: 800;
+  line-height: 1;
+}
+
+.day-card__date-text {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 0.85rem;
+  color: var(--muted);
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.day-card__badges {
+  display: inline-flex;
+  gap: 6px;
+  flex-wrap: wrap;
+}
+
+.day-card__meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.meta-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  background: rgba(17, 24, 39, 0.04);
+}
+
+.meta-pill strong {
+  font-weight: 700;
+  color: var(--ink);
+}
+
+.meta-pill--warning {
+  border-color: rgba(185, 28, 28, 0.4);
+  background: rgba(248, 113, 113, 0.18);
+  color: #991b1b;
+}
+
+.meta-pill--guide {
+  border-style: dashed;
+  background: rgba(45, 58, 100, 0.06);
+}
+
+.theme-chip {
+  background: #fff;
+  border: 1px solid var(--line);
+  border-radius: 999px;
+  padding: 4px 10px;
+  font-size: 0.75rem;
+}
+
+.theme-editor {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+}
+
+.theme-editor__button {
+  width: 20px;
+  height: 20px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 50%;
+  border: 1px solid var(--line);
+  background: #fff;
+  font-size: 0.7rem;
+}
+
+.theme-editor__input {
+  border: 1px solid var(--line);
+  border-radius: 8px;
+  padding: 4px 8px;
+  font-size: 0.78rem;
+  min-width: 160px;
+}
+
+.theme-chip.theme-chip--link {
+  cursor: pointer;
+}
+
+.theme-chip.theme-chip--map {
+  border-radius: 12px;
+}
+
+.slots {
+  display: grid;
+  gap: 10px;
+}
+
+.slot {
+  background: var(--slot-bg);
+  border: 1px dashed var(--line);
+  border-radius: 14px;
+  padding: 10px 10px 14px;
+  min-height: 70px;
+  transition: border-color 0.2s ease, background 0.2s ease;
+}
+
+.slot[data-drop-hover="true"] {
+  border-color: rgba(45, 58, 100, 0.6);
+  background: rgba(45, 58, 100, 0.08);
+}
+
+.slot__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  margin-bottom: 6px;
+}
+
+.slot__title {
+  font-size: 0.75rem;
+  font-weight: 600;
+  color: var(--muted);
+  letter-spacing: 0.08em;
+}
+
+.slot__add {
+  font-size: 0.75rem;
+  border-radius: 10px;
+  padding: 4px 8px;
+}
+
+.chiplet {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  padding: 7px 12px;
+  margin: 4px 6px 0 0;
+  border-radius: 999px;
+  background: #fff;
+  border: 1px solid var(--line);
+  font-size: 0.85rem;
+  line-height: 1.3;
+  cursor: grab;
+  user-select: none;
+  position: relative;
+}
+
+.chiplet--dragging {
+  opacity: 0.6;
+}
+
+.chiplet-placeholder {
+  display: inline-block;
+  width: 140px;
+  max-width: 100%;
+  height: 32px;
+  margin: 4px 6px 0 0;
+  border-radius: 999px;
+  border: 1px dashed rgba(45, 58, 100, 0.4);
+  background: transparent;
+}
+
+.chiplet-ghost {
+  position: fixed;
+  z-index: 1000;
+  pointer-events: none;
+  opacity: 0.9;
+  transform: translate(-50%, -50%);
+}
+
+.chiplet.locked {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.chiplet__time {
+  font-weight: 700;
+}
+
+.chiplet__actions {
+  display: inline-flex;
+  gap: 4px;
+  margin-left: 4px;
+}
+
+.chiplet__btn {
+  width: 22px;
+  height: 22px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  border-radius: 8px;
+  border: 1px solid var(--line);
+  background: #fff;
+  font-size: 0.7rem;
+}
+
+.chiplet__btn:hover {
+  background: rgba(45, 58, 100, 0.08);
+}
+
+.day-card__friends {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+}
+
+.friend-chip {
+  border-radius: 999px;
+  border: 1px solid var(--line);
+  padding: 6px 12px;
+  font-size: 0.75rem;
+  background: #fff;
+}
+
+.friend-chip.friend-chip--on[data-friend="Nana"] {
+  background: var(--friend-nana);
+}
+
+.friend-chip.friend-chip--on[data-friend="Nicole"] {
+  background: var(--friend-nicole);
+}
+
+.friend-chip.friend-chip--on[data-friend="Ken"] {
+  background: var(--friend-ken);
+}
+
+.friend-chip.friend-chip--on[data-friend="James"] {
+  background: var(--friend-james);
+}
+
+.friend-chip.friend-chip--on[data-friend="Phil"] {
+  background: var(--friend-phil);
+}
+
+.sheet-backdrop {
+  position: fixed;
+  inset: 0;
+  background: rgba(17, 24, 39, 0.36);
+  opacity: 0;
+  pointer-events: none;
+  transition: opacity 0.25s ease;
+  z-index: 60;
+}
+
+.sheet-backdrop.is-visible {
+  opacity: 1;
+  pointer-events: auto;
+}
+
+.sheet {
+  position: fixed;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: #fff;
+  border-radius: 20px 20px 0 0;
+  border: 1px solid var(--line);
+  box-shadow: 0 -12px 32px rgba(15, 23, 42, 0.16);
+  transform: translateY(105%);
+  transition: transform 0.3s ease;
+  z-index: 70;
+  max-height: 75vh;
+  display: flex;
+  flex-direction: column;
+}
+
+.sheet.sheet--open {
+  transform: translateY(0);
+}
+
+.sheet__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: 14px 18px 8px;
+}
+
+.sheet__subtitle {
+  margin: 0;
+  color: var(--muted);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.sheet__title {
+  margin: 2px 0 0;
+  font-size: 1.05rem;
+  font-weight: 650;
+}
+
+.sheet__tabs {
+  display: inline-flex;
+  gap: 8px;
+  padding: 0 18px 10px;
+  position: sticky;
+  top: 0;
+  background: var(--tab-bg);
+  backdrop-filter: blur(8px);
+  z-index: 5;
+}
+
+.tab {
+  border-radius: 999px;
+  padding: 7px 16px;
+  font-size: 0.82rem;
+}
+
+.sheet__body {
+  padding: 0 18px 18px;
+  overflow-y: auto;
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.sheet__custom {
+  border-top: 1px solid var(--line);
+  padding-top: 12px;
+  display: grid;
+  gap: 10px;
+}
+
+.sheet__custom label {
+  font-size: 0.75rem;
+  color: var(--muted);
+  display: block;
+}
+
+.sheet__custom input,
+.sheet__custom select,
+.sheet__custom textarea {
+  width: 100%;
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 6px 10px;
+  font: inherit;
+  background: #fff;
+}
+
+.sheet__custom textarea {
+  min-height: 70px;
+}
+
+.sheet__custom .sheet__custom-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.sheet-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.sheet-group__header {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-weight: 650;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+}
+
+.sheet-group__swatch {
+  width: 10px;
+  height: 10px;
+  border-radius: 3px;
+}
+
+.sheet-group__list {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(200px, 1fr));
+  gap: 10px;
+}
+
+.sheet-card {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: 12px;
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 10px 12px;
+  font-size: 0.86rem;
+  background: #fff;
+  transition: transform 0.15s ease, box-shadow 0.15s ease;
+}
+
+.sheet-card:hover {
+  transform: translateY(-1px);
+  box-shadow: 0 6px 18px rgba(15, 23, 42, 0.08);
+}
+
+.sheet-card--selected {
+  box-shadow: 0 0 0 2px rgba(45, 58, 100, 0.22);
+}
+
+.sheet-card__meta {
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 80;
+}
+
+.overlay.is-open {
+  display: flex;
+}
+
+.overlay__dialog {
+  background: #fff;
+  border-radius: 18px;
+  border: 1px solid var(--line);
+  box-shadow: 0 20px 50px rgba(15, 23, 42, 0.2);
+  width: min(100%, 960px);
+  height: min(80vh, 760px);
+  display: flex;
+  flex-direction: column;
+}
+
+.overlay__header {
+  padding: 12px 16px;
+  border-bottom: 1px solid var(--line);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+}
+
+.overlay__title {
+  margin: 0;
+  font-size: 1rem;
+  font-weight: 650;
+}
+
+.overlay__map {
+  flex: 1;
+}
+
+.wizard-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: none;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 90;
+}
+
+.wizard-overlay[aria-hidden="false"] {
+  display: flex;
+}
+
+.wizard {
+  width: min(720px, 100%);
+  max-height: 90vh;
+  background: #fff;
+  border-radius: 20px;
+  border: 1px solid var(--line);
+  box-shadow: var(--shadow);
+  display: flex;
+  flex-direction: column;
+}
+
+.wizard__header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 16px;
+  padding: 18px 22px;
+  border-bottom: 1px solid var(--line);
+}
+
+.wizard__eyebrow {
+  margin: 0;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  color: var(--muted);
+}
+
+.wizard__title {
+  margin: 4px 0 0;
+  font-size: 1.3rem;
+}
+
+.wizard__form {
+  padding: 18px 22px 24px;
+  overflow-y: auto;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.wizard__field {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 0.85rem;
+}
+
+.wizard__field--inline {
+  margin-top: 4px;
+}
+
+.wizard__row {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+}
+
+.wizard__row .wizard__field {
+  flex: 1 1 200px;
+}
+
+.wizard__fieldset {
+  border: 1px solid var(--line);
+  border-radius: 14px;
+  padding: 12px 14px;
+  display: grid;
+  gap: 10px;
+}
+
+.wizard__checkbox {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.wizard__hint {
+  margin: 0;
+  font-size: 0.75rem;
+  color: var(--muted);
+}
+
+.wizard__actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 8px;
+}
+
+.wizard input,
+.wizard select,
+.wizard textarea {
+  border: 1px solid var(--line);
+  border-radius: 10px;
+  padding: 8px 10px;
+  font: inherit;
+  background: #fff;
+}
+
+.wizard textarea {
+  resize: vertical;
+  min-height: 64px;
+}
+
+.leaflet-container {
+  width: 100%;
+  height: 100%;
+  font-family: inherit;
+}
+
+.map-marker {
+  width: 28px;
+  height: 28px;
+  border-radius: 50%;
+  background: #2d3a64;
+  color: #fff;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 0.75rem;
+  font-weight: 700;
+  border: 2px solid #fff;
+  box-shadow: 0 4px 12px rgba(0, 0, 0, 0.25);
+}
+
+.empty-state {
+  color: var(--muted);
+  font-size: 0.82rem;
+}
+
+@media (max-width: 600px) {
+  .sheet-group__list {
+    grid-template-columns: repeat(auto-fill, minmax(160px, 1fr));
+  }
+}
+
+@media print {
+  body,
+  .main {
+    background: #fff !important;
+  }
+
+  .site-header,
+  .toolbar-group--actions,
+  .legend,
+  #pool,
+  #sheet,
+  #sheetBackdrop,
+  #mapOverlay,
+  #wizardOverlay,
+  #githubOverlay,
+  .btn,
+  .slot__add,
+  .chiplet__actions,
+  .theme-editor__button {
+    display: none !important;
+  }
+
+  .calendar {
+    grid-template-columns: repeat(2, minmax(0, 1fr));
+    gap: 12px;
+  }
+
+  .day-card {
+    box-shadow: none;
+    border: 1px solid #d1d5db;
+    break-inside: avoid;
+  }
+
+  .chiplet {
+    border-color: #d1d5db;
+  }
+
+  .friend-chip {
+    border: none;
+    background: transparent;
+    padding: 0;
+  }
+
+  .banner,
+  .filter-feedback {
+    display: none !important;
+  }
+}


### PR DESCRIPTION
## Summary
- load the planner from a shared data/trip.json schema with expanded coordinates, activities, stays, and bookings
- add idea pool management, travel-time estimates, availability warnings, manual item creation, and shareable read-only links with hash payloads
- provide setup and GitHub dialogs, multi-select filters with feedback, and print-focused styling updates

## Testing
- node --check scripts/app.js
- python -m json.tool data/trip.json > /tmp/validate.json

------
https://chatgpt.com/codex/tasks/task_e_68c99a60657483338fb4752e3e9d28f3