### PR TITLE
Declare overlay mode state before use

### DIFF
--- a/scripts/app.js
+++ b/scripts/app.js
@@ -48,6 +48,7 @@ let mapInstance = null;
 let mapMarkersLayer = null;
 let mapRouteLayer = null;
 let activeMapDate = null;
+let overlayMode = null;
 const travelRequests = new Map();
 let routingKeyPromptActive = false;
 
@@ -1719,6 +1720,7 @@ function formatLongDate(dateKey) {
 function openMap(dateKey) {
   const plan = ensureDay(dateKey);
   activeMapDate = dateKey;
+  overlayMode = 'map';
   mapOverlay.classList.add('is-open');
   mapOverlay.setAttribute('aria-hidden', 'false');
   document.body.classList.add('map-open');
@@ -1749,6 +1751,7 @@ function openMap(dateKey) {
 }
 
 function closeMap() {
+  overlayMode = null;
   mapOverlay.classList.remove('is-open');
   mapOverlay.setAttribute('aria-hidden', 'true');
   document.body.classList.remove('map-open');


### PR DESCRIPTION
## Summary
- declare a dedicated `overlayMode` state variable so overlay handlers no longer assign to an implicit global
- keep the overlay mode in sync when opening and closing the map overlay to avoid future inconsistencies

## Testing
- not run (not available)


------
https://chatgpt.com/codex/tasks/task_e_68cb28f577e88333a8a0c760f23e95f5